### PR TITLE
DM-34437: Add BroadcastCategory to messages

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Install tox and LTD Conveyor
         run: pip install tox ltd-conveyor

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Change log
 ##########
 
+0.3.0 (2022-04-14)
+==================
+
+- Broadcast messages can now have a "category," which you can set in the YAML front-matter.
+  The default behavior is ``category: maintenance``, which matches the idiomatic use of broadcasts up to this point.
+  However, you can also set ``category: info`` to publish informational messages, like general announcements.
+  The category is present in the JSON data model for broadcasts published from the API.
+  Note that "category" is an enumeration: only ``info`` or ``maintenance`` are allowed values.
+- Semaphore is now cross-published to the GitHub Container Registry, ``ghcr.io/lsst-sqre/semaphore``.
+- Semaphore now runs on Python 3.10.
+
 0.2.1 (2021-08-12)
 ==================
 

--- a/src/semaphore/broadcast/markdown.py
+++ b/src/semaphore/broadcast/markdown.py
@@ -20,6 +20,7 @@ from mdit_py_plugins.front_matter import front_matter_plugin
 from pydantic import BaseModel, root_validator, validator
 
 from .models import (
+    BroadcastCategory,
     BroadcastMessage,
     FixedExpirationScheduler,
     OneTimeScheduler,
@@ -155,6 +156,7 @@ class BroadcastMarkdown:
             body_md=self.body,
             scheduler=self._make_scheduler(),
             enabled=self.metadata.enabled,
+            category=self.metadata.category,
         )
 
     def _make_scheduler(self) -> Scheduler:
@@ -563,6 +565,9 @@ class BroadcastMarkdownFrontMatter(BaseModel):
 
     enabled: bool = True
     """Toggle to disable a message, overriding the scheduling."""
+
+    category: BroadcastCategory = BroadcastCategory.maintenance
+    """Broadcast category."""
 
     @root_validator(pre=True)
     def propagate_timezone(

--- a/src/semaphore/broadcast/models.py
+++ b/src/semaphore/broadcast/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING
 
 import arrow
@@ -23,7 +24,18 @@ __all__ = [
     "OneTimeScheduler",
     "OpenEndedScheduler",
     "FixedExpirationScheduler",
+    "BroadcastCategory",
 ]
+
+
+class BroadcastCategory(str, Enum):
+    """Broadcast message categories."""
+
+    maintenance: str = "maintenance"
+    """System maintenance event messages."""
+
+    info: str = "info"
+    """Information message (marketing, announcements, etc.)."""
 
 
 class Scheduler(ABC):
@@ -264,6 +276,11 @@ class BroadcastMessage:
 
     enabled: bool = True
     """A toggle for disabling a message, overriding the scheduler."""
+
+    category: BroadcastCategory = BroadcastCategory.maintenance
+    """The broadcast's content category, such as ``info`` or
+    ``maintenance``.
+    """
 
     @property
     def active(self) -> bool:

--- a/src/semaphore/handlers/v1/models.py
+++ b/src/semaphore/handlers/v1/models.py
@@ -2,23 +2,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from markdown_it import MarkdownIt
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from semaphore.broadcast.models import BroadcastMessage
+from semaphore.broadcast.models import BroadcastCategory, BroadcastMessage
 
 
 class FormattedText(BaseModel):
     """Text that is formatted in both markdown and HTML."""
 
-    gfm: str
-    """The GitHub-flavored Markdown version of the text."""
+    gfm: str = Field(title="The GitHub-flavored Markdown-formatted text.")
 
-    html: str
-    """The HTML-formatted version of the text."""
+    html: str = Field(title="The HTML-formatted text.")
 
     @classmethod
     def from_gfm(cls, gfm_text: str, inline: bool = False) -> FormattedText:
@@ -47,25 +44,35 @@ class FormattedText(BaseModel):
 class BroadcastMessageModel(BaseModel):
     """A broadcast message."""
 
-    id: str
-    """The message's identifier."""
+    id: str = Field(title="The message's identifier")
 
-    summary: FormattedText
-    """The message summary."""
+    summary: FormattedText = Field(title="The message summary")
 
-    body: Optional[FormattedText]
-    """The body content (optional)."""
+    body: Optional[FormattedText] = Field(title="The body content (optional).")
 
-    active: bool
-    """True if the message should be broadcast based on its schedule and
-    being enabled.
-    """
+    active: bool = Field(
+        title="Whether the message should be displayed",
+        description=(
+            "True if the message should be broadcast based on its schedule "
+            "and being enabled."
+        ),
+    )
 
-    enabled: bool
-    """A toggle that, when false, disables a message even if scheduled."""
+    enabled: bool = Field(
+        title="Toggle for whether the message is enabled",
+        description=(
+            "When false, the message isn't shown even if it is scheduled"
+        ),
+    )
 
-    stale: bool
-    """True if the message has not future scheduled broadcast events."""
+    stale: bool = Field(
+        title="Flag indicated the message is stable",
+        description=(
+            "True if the message has no future scheduled broadcast events."
+        ),
+    )
+
+    category: BroadcastCategory = Field(title="Category of the message.")
 
     @classmethod
     def from_broadcast_message(
@@ -95,4 +102,5 @@ class BroadcastMessageModel(BaseModel):
             active=message.active,
             enabled=message.enabled,
             stale=message.stale,
+            category=message.category,
         )

--- a/tests/broadcast/markdown_test.py
+++ b/tests/broadcast/markdown_test.py
@@ -88,6 +88,7 @@ def test_evergreen(broadcasts_dir: Path) -> None:
     assert broadcast.identifier == source_path
     assert broadcast.active is True
     assert broadcast.stale is False
+    assert broadcast.category == "maintenance"
 
 
 def test_evergreen_no_body(broadcasts_dir: Path) -> None:
@@ -119,6 +120,32 @@ def test_evergreen_disabled(broadcasts_dir: Path) -> None:
     broadcast = md.to_broadcast()
     assert broadcast.active is False
     assert broadcast.scheduler.is_active() is True
+
+
+def test_evergreen_info(broadcasts_dir: Path) -> None:
+    source_path = "evergreen-info.md"
+    text = broadcasts_dir.joinpath(source_path).read_text()
+
+    expected_summary = "Informational markdown-formatted broadcast message."
+    expected_body = (
+        "The extended message body, shown *only* when the user interacts "
+        "with the message, and formatted as markdown.\n"
+    )
+
+    md = BroadcastMarkdown(text, source_path)
+    assert md.text == text
+    assert md.metadata.summary == expected_summary
+    assert md.metadata.env is None
+    assert md.body == expected_body
+
+    broadcast = md.to_broadcast()
+    assert isinstance(broadcast.scheduler, PermaScheduler)
+    assert broadcast.summary_md == expected_summary
+    assert broadcast.body_md == expected_body
+    assert broadcast.identifier == source_path
+    assert broadcast.active is True
+    assert broadcast.stale is False
+    assert broadcast.category == "info"
 
 
 def test_env_list(broadcasts_dir: Path) -> None:

--- a/tests/data/broadcasts/evergreen-info.md
+++ b/tests/data/broadcasts/evergreen-info.md
@@ -1,0 +1,6 @@
+---
+summary: Informational markdown-formatted broadcast message.
+category: info
+---
+
+The extended message body, shown *only* when the user interacts with the message, and formatted as markdown.


### PR DESCRIPTION
The category is an "enum" that defaults to "maintenance" category, which is our current usage. The new category that's now available is "info." Apps like squareone can display messages from categories differently; like red for a maintenance message, or Rubin primary teal for an info message.

In markdown front-matter, this category can be set via the category key:

```md
---
category: info
---
```

This is propagated into BroadcastMessage's category attribute. Finally, the model for broadcast messages in the v1 API also propagates this information in the "category" field.

For messages that don't set a category, the default is always "maintenance", which is our current idiomatic treatment of messages.