### PR TITLE
DM-51547: Add "notice" broadcast category

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [lint, test]
+    timeout-minutes: 10
 
     # Only do Docker builds of tagged releases and pull requests from ticket
     # branches.  This will still trigger on pull requests from untrusted
@@ -77,45 +78,17 @@ jobs:
     # but in this case the build will fail with an error since the secret
     # won't be set.
     if: >
-      startsWith(github.ref, 'refs/tags/')
-      || startsWith(github.head_ref, 'tickets/')
+      github.event_name != 'merge_group'
+      && (startsWith(github.ref, 'refs/tags/')
+          || startsWith(github.head_ref, 'tickets/'))
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # full-depth clone for setuptools_scm
+          fetch-depth: 0
 
-      - name: Define the Docker tag
-        id: vars
-        run: echo ::set-output name=tag::$(scripts/docker-tag.sh)
-
-      - name: Print the tag
-        id: print
-        run: echo ${{steps.vars.outputs.tag}}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+      - uses: lsst-sqre/build-and-push-to-ghcr@v1
+        id: build
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: |
-            lsstsqre/semaphore:${{ steps.vars.outputs.tag }}
-            ghcr.io/lsst-sqre/semaphore:${{ steps.vars.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          image: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter"
+  }
+}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,10 @@
 Change log
 ##########
 
-Unreleased
-==========
+0.5.0 (2024-06-26)
+==================
+
+- Reorganized the broadcast message categories to be: `info`, `notice` (new), and `outage` (new). The old `maintenance` category has been removed and is now equivalent to `notice`.
 
 - Documentation improvements:
 

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@
 # file.
 .PHONY: update-deps
 update-deps:
-	pip install --upgrade pip-tools pip setuptools
+	python -m pip install --upgrade pip-tools pip setuptools
 	pip-compile --upgrade --resolver=backtracking --build-isolation --allow-unsafe --generate-hashes --output-file requirements/main.txt requirements/main.in
 	pip-compile --upgrade --resolver=backtracking --build-isolation --allow-unsafe --generate-hashes --output-file requirements/dev.txt requirements/dev.in
 
 # npm dependencies have to be installed for pre-commit eslint to work.
 .PHONY: init
 init:
-	pip install --editable .
-	pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
+	python -m pip install --editable .
+	python -m pip install --upgrade -r requirements/main.txt -r requirements/dev.txt
 	rm -rf .tox
 	pip install --upgrade tox pre-commit
 	pre-commit install

--- a/src/semaphore/broadcast/markdown.py
+++ b/src/semaphore/broadcast/markdown.py
@@ -618,7 +618,7 @@ class BroadcastMarkdownFrontMatter(BaseModel):
     enabled: bool = True
     """Toggle to disable a message, overriding the scheduling."""
 
-    category: BroadcastCategory = BroadcastCategory.maintenance
+    category: BroadcastCategory = BroadcastCategory.notice
     """Broadcast category."""
 
     @root_validator(pre=True)

--- a/src/semaphore/broadcast/models.py
+++ b/src/semaphore/broadcast/models.py
@@ -37,6 +37,9 @@ class BroadcastCategory(str, Enum):
     info: str = "info"
     """Information message (marketing, announcements, etc.)."""
 
+    notice: str = "notice"
+    """A notice message about upcoming changes or maintenance."""
+
 
 class Scheduler(ABC):
     """A scheduler for messages."""

--- a/src/semaphore/broadcast/models.py
+++ b/src/semaphore/broadcast/models.py
@@ -31,7 +31,7 @@ __all__ = [
 class BroadcastCategory(str, Enum):
     """Broadcast message categories."""
 
-    maintenance: str = "maintenance"
+    outage: str = "outage"
     """System maintenance event messages."""
 
     info: str = "info"

--- a/src/semaphore/broadcast/models.py
+++ b/src/semaphore/broadcast/models.py
@@ -280,7 +280,7 @@ class BroadcastMessage:
     enabled: bool = True
     """A toggle for disabling a message, overriding the scheduler."""
 
-    category: BroadcastCategory = BroadcastCategory.maintenance
+    category: BroadcastCategory = BroadcastCategory.notice
     """The broadcast's content category, such as ``info`` or
     ``maintenance``.
     """

--- a/tests/broadcast/markdown_test.py
+++ b/tests/broadcast/markdown_test.py
@@ -88,7 +88,7 @@ def test_evergreen(broadcasts_dir: Path) -> None:
     assert broadcast.identifier == source_path
     assert broadcast.active is True
     assert broadcast.stale is False
-    assert broadcast.category == "maintenance"
+    assert broadcast.category == "notice"
 
 
 def test_evergreen_no_body(broadcasts_dir: Path) -> None:


### PR DESCRIPTION
Reorganized the broadcast message categories to be: `info`, `notice` (new), and `outage` (new). The old `maintenance` category has been removed and is now equivalent to `notice`.