### PR TITLE
DM-54797: Partly update GitHub CI configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,19 +1,22 @@
 name: CI
 
 "on":
+  merge_group: {}
+  pull_request: {}
   push:
     branches-ignore:
       # These should always correspond to pull requests, so ignore them for
       # the push trigger and let them be triggered by the pull_request
-      # trigger, avoiding running the workflow twice.  This is a minor
+      # trigger, avoiding running the workflow twice. This is a minor
       # optimization so there's no need to ensure this is comprehensive.
       - "dependabot/**"
+      - "gh-readonly-queue/**"
       - "renovate/**"
+      - "t/**"
       - "tickets/**"
       - "u/**"
-    tags:
-      - "*"
-  pull_request: {}
+  release:
+    types: [published]
 
 jobs:
   lint:
@@ -68,27 +71,19 @@ jobs:
         run: tox -e py,coverage-report,typing
 
   build:
-    runs-on: ubuntu-latest
     needs: [lint, test]
-    timeout-minutes: 10
+    secrets: inherit
+    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v3
+    with:
+      images: ghcr.io/${{ github.repository }}
 
-    # Only do Docker builds of tagged releases and pull requests from ticket
-    # branches.  This will still trigger on pull requests from untrusted
+    # Only do Docker builds of releases and pull requests from ticket
+    # branches. This will still trigger on pull requests from untrusted
     # repositories whose branch names match our tickets/* branch convention,
     # but in this case the build will fail with an error since the secret
     # won't be set.
     if: >
-      github.event_name != 'merge_group'
-      && (startsWith(github.ref, 'refs/tags/')
-          || startsWith(github.head_ref, 'tickets/'))
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: lsst-sqre/build-and-push-to-ghcr@v1
-        id: build
-        with:
-          image: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      (github.event_name == 'release' && github.event.action == 'published')
+      || (github.event_name != 'merge_group'
+          && (startsWith(github.head_ref, 'tickets/')
+              || startsWith(github.head_ref, 't/')))


### PR DESCRIPTION
Update the GitHub CI configuration just enough to allow `t/*` branches, to switch to multi-platform builds, and to build versioned images on release rather than on tag.