### PR TITLE
DM-54797: Drop click and sphinx-click as dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ requires-python = ">=3.14"
 dependencies = [
     "aiofiles",
     "arrow",
-    "click",
     "fastapi",
     "fastapi-sqlalchemy",
     "gidgethub",
@@ -62,7 +61,6 @@ dev = [
 docs = [
     "documenteer[guide]",
     "scriv[toml]>=1.5",
-    "sphinx-click",
 ]
 lint = [
     "pre-commit",

--- a/uv.lock
+++ b/uv.lock
@@ -155,11 +155,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.0.6"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/7b/1755ed2c6bfabd1d98b37ae73152f8dcf94aa40fee119d163c19ed484704/cachetools-7.0.6.tar.gz", hash = "sha256:e5d524d36d65703a87243a26ff08ad84f73352adbeafb1cde81e207b456aaf24", size = 37526, upload-time = "2026-04-20T19:02:23.289Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/1d/7cbe8f84352789be3dcbb1239f425984f353efa253deeeff38af600870b3/cachetools-7.1.0.tar.gz", hash = "sha256:ea5406e92956f9006b121f8032177c6b02cc5f9a488d1e53b2e4d9cb5aae15c6", size = 40085, upload-time = "2026-05-01T21:20:04.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/c4/cf76242a5da1410917107ff14551764aa405a5fd10cd10cf9a5ca8fa77f4/cachetools-7.0.6-py3-none-any.whl", hash = "sha256:4e94956cfdd3086f12042cdd29318f5ced3893014f7d0d059bf3ead3f85b7f8b", size = 13976, upload-time = "2026-04-20T19:02:21.187Z" },
+    { url = "https://files.pythonhosted.org/packages/87/42/e09974bc74ea2791f985dff3d7f06065d11abcc31da6c46fc5f83046516e/cachetools-7.1.0-py3-none-any.whl", hash = "sha256:05afd1d309309e7c8971db462b4cf516d93fa8c9aea1b906e26e61b4399d0d82", size = 16748, upload-time = "2026-05-01T21:20:02.879Z" },
 ]
 
 [[package]]
@@ -1767,7 +1767,6 @@ source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "arrow" },
-    { name = "click" },
     { name = "fastapi" },
     { name = "fastapi-sqlalchemy" },
     { name = "gidgethub" },
@@ -1799,7 +1798,6 @@ dev = [
 docs = [
     { name = "documenteer", extra = ["guide"] },
     { name = "scriv" },
-    { name = "sphinx-click" },
 ]
 lint = [
     { name = "pre-commit" },
@@ -1820,7 +1818,6 @@ typing = [
 requires-dist = [
     { name = "aiofiles" },
     { name = "arrow" },
-    { name = "click" },
     { name = "fastapi" },
     { name = "fastapi-sqlalchemy" },
     { name = "gidgethub" },
@@ -1852,7 +1849,6 @@ dev = [
 docs = [
     { name = "documenteer", extras = ["guide"] },
     { name = "scriv", extras = ["toml"], specifier = ">=1.5" },
-    { name = "sphinx-click" },
 ]
 lint = [
     { name = "pre-commit" },
@@ -1977,20 +1973,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/9f/16c79a06f4c6772124f03f1d69a0394bc1f52c154202db5d5905cb3579c7/sphinx_automodapi-0.22.0.tar.gz", hash = "sha256:9a6745d606eb948321f0bb7bd4511dc6d8481da8819caa1604d7138910173b38", size = 56683, upload-time = "2025-12-13T00:19:52.962Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/a0/1a0c44070d2f7e8761ca221d51e1ce8f959b2a0add4cab13de0a677f81bc/sphinx_automodapi-0.22.0-py3-none-any.whl", hash = "sha256:8ecbe8c8ba33a1e3dbe03aea06879062567d611b543da3f33367512d45118b01", size = 111939, upload-time = "2025-12-13T00:19:51.596Z" },
-]
-
-[[package]]
-name = "sphinx-click"
-version = "6.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "docutils" },
-    { name = "sphinx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/ed/a9767cd1b8b7fbdf260a89d5c8c86e20e3536b9878579e5ab7965a291e55/sphinx_click-6.2.0.tar.gz", hash = "sha256:fc78b4154a4e5159462e36de55b8643747da6cda86b3b52a8bb62289e603776c", size = 27035, upload-time = "2025-12-04T19:33:05.437Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/bd/cb244695f67f77b0a36200ce1670fc42a6fe2770847e870daab99cc2b177/sphinx_click-6.2.0-py3-none-any.whl", hash = "sha256:1fb1851cb4f2c286d43cbcd57f55db6ef5a8d208bfc3370f19adde232e5803d7", size = 8939, upload-time = "2025-12-04T19:33:04.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The nascent command line was removed earlier since it only supported a help command.