### PR TITLE
DM-54797: Remove types from docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ from urllib.parse import quote, urlencode
 from documenteer.conf.guide import *
 
 
-def create_github_app_qs(domain="data-dev.lsst.cloud"):
+def create_github_app_qs(domain: str = "data-dev.lsst.cloud") -> str:
     """Create a URL query string with the GitHub App configuration.
 
     See
@@ -12,13 +12,13 @@ def create_github_app_qs(domain="data-dev.lsst.cloud"):
 
     Parameters
     ----------
-    domain : `str`, optional
+    domain
         The domain name of the RSP environment. This is used to template some
         of the GitHub App configuration.
 
     Returns
     -------
-    qs : `str`
+    str
         The query string with the GitHub App configuration.
     """
     parameters = [
@@ -43,20 +43,22 @@ def create_github_app_qs(domain="data-dev.lsst.cloud"):
     return urlencode(parameters, quote_via=quote)
 
 
-def format_org_url(org="lsst-sqre", domain="data-dev.lsst.cloud"):
+def format_org_url(
+    org: str = "lsst-sqre", domain: str = "data-dev.lsst.cloud"
+) -> str:
     """Format the URL creating the app for an organization.
 
     Parameters
     ----------
-    org : `str`, optional
+    org
         The GitHub organization name where the app is created.
-    domain : `str`, optional
+    domain
         The domain name of the RSP environment. This is used to template some
         of the GitHub App configuration.
 
     Returns
     -------
-    url : `str`
+    str
         The URL to create the GitHub App.
     """
     qs = create_github_app_qs(domain=domain)
@@ -64,18 +66,18 @@ def format_org_url(org="lsst-sqre", domain="data-dev.lsst.cloud"):
     return url
 
 
-def format_personal_url(domain="data-dev.lsst.cloud"):
+def format_personal_url(domain: str = "data-dev.lsst.cloud") -> str:
     """Format the URL creating the app for a user account.
 
     Parameters
     ----------
-    domain : `str`, optional
+    domain
         The domain name of the RSP environment. This is used to template some
         of the GitHub App configuration.
 
     Returns
     -------
-    url : `str`
+    str
         The URL to create the GitHub App.
     """
     qs = create_github_app_qs(domain=domain)

--- a/src/semaphore/broadcast/markdown.py
+++ b/src/semaphore/broadcast/markdown.py
@@ -78,10 +78,10 @@ class BroadcastMarkdown:
 
     Properties
     ----------
-    text : `str`
+    text
         The content of the markdown message (including YAML-formatted
         front-matter).
-    identifier : `str`
+    identifier
         A unique identifier that is associated with the markdown content.
     """
 
@@ -136,12 +136,12 @@ class BroadcastMarkdown:
 
         Parameters
         ----------
-        env_name : `str`
+        env_name
             Name of the Phalanx environment (e.g., `idf-prod`).
 
         Returns
         -------
-        `bool`
+        bool
             `True`, if the message should be included in that environment's
             broadcast message. `False` otherwise.
         """
@@ -683,7 +683,7 @@ def convert_to_tzinfo(v: Any) -> datetime.tzinfo:
 
     Parameters
     ----------
-    v : datetime.tzinfo, str
+    v
         A value to convert into a timezone.
     """
     if isinstance(v, datetime.tzinfo):
@@ -708,9 +708,9 @@ def convert_to_arrow(
 
     Parameters
     ----------
-    v : datetime.date, datetime.datetime, str
+    v
         A value to convert into a datetime.
-    default_tz : datetime.tzinfo
+    default_tz
         A default timezone. If neither ``v`` has a timezone or ``default_tz``
         is set, the default timezone is UTC.
     """
@@ -752,7 +752,7 @@ def convert_to_timedelta(v: Any) -> datetime.timedelta | None:
 
     Parameters
     ----------
-    v : datetime.timedelta, str
+    v
         A value to convert into a timedelta.
     """
     if v is None:

--- a/src/semaphore/broadcast/models.py
+++ b/src/semaphore/broadcast/models.py
@@ -113,14 +113,14 @@ class OneTimeScheduler(Scheduler):
 
         Parameters
         ----------
-        start : `arrow.Arrow`
+        start
             A start date as an arrow object.
-        ttl : `datetime.timedela`
+        ttl
             The duration of the event.
 
         Returns
         -------
-        `OneTimeScheduler`
+        OneTimeScheduler
             The scheduler.
         """
         end = start.shift(seconds=ttl.total_seconds())
@@ -138,12 +138,12 @@ class RecurringScheduler(Scheduler):
 
     Parameters
     ----------
-    rruleset : `dateutil.rrule.rruleset`
+    rruleset
         A recurrence ruleset from the dateutil package. Rulesets can contain
         both repeats, one-time dates, one-time exclusions, and so on. The
         rruleset **must** have a UTC timezone. Time zones are not validated
         by the constructor.
-    ttl : `datetime.timedela`
+    ttl
         The duration of the event.
     """
 

--- a/src/semaphore/broadcast/repository.py
+++ b/src/semaphore/broadcast/repository.py
@@ -24,7 +24,7 @@ class BroadcastMessageRepository:
 
     Parameters
     ----------
-    messages : sequence of `BroadcastMessage`, optional
+    messages
         Bootstrap the repository with these messages, optionally. Messages
         can always be added later using the `add` method.
     """
@@ -43,7 +43,7 @@ class BroadcastMessageRepository:
 
         Parameters
         ----------
-        message : `semaphore.broadcast.models.BroadcastMessage`
+        message
             Description
         """
         self._messages[message.identifier] = message
@@ -56,12 +56,12 @@ class BroadcastMessageRepository:
 
         Parameters
         ----------
-        identifier : hashable
+        identifier
             The message's identifier.
 
         Returns
         -------
-        `semaphore.broadcast.models.BroadcastMessage`
+        BroadcastMessage
             The broadcast message.
 
         Raises
@@ -76,7 +76,7 @@ class BroadcastMessageRepository:
 
         Parameters
         ----------
-        identifier : hashable
+        identifier
             The message's identifier.
 
         Returns

--- a/src/semaphore/github/broadcastservices.py
+++ b/src/semaphore/github/broadcastservices.py
@@ -91,11 +91,11 @@ async def update_broadcast_repo_from_push_event(
 
     Parameters
     ----------
-    event : `gidgethub.sansio.Event`
+    event
         The parsed event payload.
-    broadcast_repo : ``BroadcastMessageRepository``
+    broadcast_repo
         The broadcast message repository.
-    github_client : `gidgethub.httpx.GitHubAPI`
+    github_client
         The GitHub API client, pre-authorized as an app installation.
     logger
         The logger instance
@@ -177,7 +177,7 @@ def is_broadcast_message(github_path: str) -> bool:
 
     Parameters
     ----------
-    github_path : `str`
+    github_path
         Posix file path in a GitHub repository.
 
     Returns
@@ -214,16 +214,16 @@ async def add_file_to_repository(
 
     Parameters
     ----------
-    file_path : str
+    file_path
         Posix path of the message's file in GitHub.
-    message_ref : `GitHubMessageRef`
+    message_ref
         Reference for the message.
-    contents_url : `str`
+    contents_url
         The URI template for the repository's contents (the template
         includs a ``path`` variable).
-    broadcast_repo : ``BroadcastMessageRepository``
+    broadcast_repo
         The broadcast message repository.
-    github_client : `gidgethub.httpx.GitHubAPI`
+    github_client
         The GitHub API client, pre-authorized as an app installation.
     logger
         The logger instance
@@ -282,9 +282,9 @@ async def bootstrap_broadcast_repo(
 
     Parameters
     ----------
-    http_client : httpx.AsyncClient
+    http_client
         The httpx client.
-    broadcast_repo : ``BroadcastMessageRepository``
+    broadcast_repo
         The broadcast message repository.
     logger
         The logger instance.
@@ -330,9 +330,9 @@ async def iter_installations(
 
     Parameters
     ----------
-    github_client : `gidgethub.httpx.GitHubAPI`
+    github_client
         The GitHub client.
-    jwt : `str`
+    jwt
         The JWT for the GitHub application. See `get_app_jwt`.
 
     Yields
@@ -357,7 +357,7 @@ async def iter_installation_repositories(
 
     Parameters
     ----------
-    github_client : `gidgethub.httpx.GitHubAPI`
+    github_client
         The GitHub client that is pre-authorized with an installation ID,
         see `create_github_installation_client`.
 
@@ -383,14 +383,14 @@ async def iter_repo_dir_contents(
 
     Parameters
     ----------
-    github_client : `gidgethub.httpx.GitHubAPI`
+    github_client
         The GitHub client that is pre-authorized with an installation ID,
         see `create_github_installation_client`.
-    contents_url : `str`
+    contents_url
         The contents URL for the repository, which is a templated URI,
         Example:
         ``https://api.github.com/repos/lsst-sqre/semaphore-demo/contents/{+path}``
-    directory_path : `str`
+    directory_path
         The directory path to iterate in.
 
     Yields

--- a/src/semaphore/github/client.py
+++ b/src/semaphore/github/client.py
@@ -34,7 +34,7 @@ def get_app_jwt() -> str:
 
     Parameters
     ----------
-    http_client : httpx.AsyncClient
+    http_client
         The httpx client.
 
     Returns
@@ -67,15 +67,16 @@ def create_github_client(
 
     Parameters
     ----------
-    http_client : httpx.AsyncClient
+    http_client
         The httpx client.
-    oauth_token : str, optional
+    oauth_token
         If set, the client is authenticated with the oauth token (common
         for clients acting as an app installation or on behalf of a user).
 
     Returns
     -------
     gidgethub.httpx.GitHubAPI
+        Created GitHub client.
     """
     return GitHubAPI(
         http_client, "lsst-sqre/semaphore", oauth_token=oauth_token
@@ -91,9 +92,9 @@ async def create_github_installation_client(
 
     Parameters
     ----------
-    http_client : httpx.AsyncClient
+    http_client
         The httpx client.
-    installation_id : str
+    installation_id
         The installation ID, often obtained from a webhook payload
         (``installation.id`` path), or from the ``id`` key returned by
         `iter_installations`.

--- a/src/semaphore/github/webhooks.py
+++ b/src/semaphore/github/webhooks.py
@@ -34,11 +34,11 @@ async def handle_push_event(
 
     Parameters
     ----------
-    event : `gidgethub.sansio.Event`
+    event
         The parsed event payload.
-    broadcast_repo : ``BroadcastMessageRepository``
+    broadcast_repo
         The broadcast message repository.
-    github_client : `gidgethub.httpx.GitHubAPI`
+    github_client
         The GitHub API client, pre-authorized as an app installation.
     logger
         The logger instance

--- a/src/semaphore/handlers/v1/models.py
+++ b/src/semaphore/handlers/v1/models.py
@@ -21,14 +21,14 @@ class FormattedText(BaseModel):
 
         Parameters
         ----------
-        gfm_text : `str`
+        gfm_text
             GitHub flavored markdown.
-        inline : `bool`
+        inline
             If `True`, no paragraph tags are added to the HTML content.
 
         Returns
         -------
-        `FormattedText`
+        FormattedText
             The formatted text, containing both markdown and HTML renderings.
         """
         md_parser = MarkdownIt("gfm-like")
@@ -81,12 +81,12 @@ class BroadcastMessageModel(BaseModel):
 
         Parameters
         ----------
-        message : `semaphore.broadcast.models.BroadcastMessage`
+        message
             The message domain model, usually obtained from a repository.
 
         Returns
         -------
-        `BroadcastMessageModel`
+        BroadcastMessageModel
             The message entity for the v1 API.
         """
         formatted_summary = FormattedText.from_gfm(message.summary_md)


### PR DESCRIPTION
Modern Sphinx can use the type annotations to get type information, so duplicating that information in the docstrings is no longer required.