### PR TITLE
DM-54797: Update application setup to current template

### DIFF
--- a/changelog.d/20260501_171347_rra_DM_54797.md
+++ b/changelog.d/20260501_171347_rra_DM_54797.md
@@ -1,0 +1,7 @@
+### Backwards-incompatible changes
+
+- Rename `config.profile` to `config.logProfile` in the Helm configuration to make it clearer what this field controls.
+
+### New features
+
+- Add support for configuring a Slack webhook for alerting, and send uncaught exceptions to that webhook if configured.

--- a/src/semaphore/config.py
+++ b/src/semaphore/config.py
@@ -1,80 +1,22 @@
-"""Configuration for Semaphore.
-
-There are two, mostly-parallel models defined here.  The ones ending in
-``Settings`` are the pydantic models used to read the settings file from disk,
-the root of which is `SettingsFile`.  This is then processed and broken up into
-configuration dataclasses for various components and then exposed to the rest
-of Semaphore as the `Config` object.
-"""
+"""Configuration for Semaphore."""
 
 from __future__ import annotations
 
-from enum import StrEnum
 from typing import Self
 
 from pydantic import Field, SecretStr, field_validator, model_validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from safir.logging import LogLevel, Profile
 
-__all__ = ["Config", "LogLevel", "Profile"]
-
-
-class Profile(StrEnum):
-    """Logging profiles."""
-
-    production = "production"
-
-    development = "development"
-
-
-class LogLevel(StrEnum):
-    """Logging levels."""
-
-    DEBUG = "DEBUG"
-
-    INFO = "INFO"
-
-    WARNING = "WARNING"
-
-    ERROR = "ERROR"
-
-    CRITICAL = "CRITICAL"
+__all__ = ["Config", "config"]
 
 
 class Config(BaseSettings):
     """Configuration for Semaphore."""
 
-    name: str = Field("semaphore", validation_alias="SAFIR_NAME")
-
-    profile: Profile = Field(
-        Profile.production, validation_alias="SAFIR_PROFILE"
+    model_config = SettingsConfigDict(
+        env_prefix="SEMAPHORE_", case_sensitive=False
     )
-
-    log_level: LogLevel = Field(
-        LogLevel.INFO, validation_alias="SAFIR_LOG_LEVEL"
-    )
-
-    logger_name: str = Field("semaphore", validation_alias="SAFIR_LOGGER")
-
-    github_app_id: str | None = Field(
-        None, validation_alias="SEMAPHORE_GITHUB_APP_ID"
-    )
-    """The GitHub App ID, as determined by GitHub when setting up a GitHub
-    App.
-    """
-
-    github_webhook_secret: SecretStr | None = Field(
-        None, validation_alias="SEMAPHORE_GITHUB_WEBHOOK_SECRET"
-    )
-    """The GitHub app's webhook secret, as set when the App was created. See
-    https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks
-    """
-
-    github_app_private_key: SecretStr | None = Field(
-        None, validation_alias="SEMAPHORE_GITHUB_APP_PRIVATE_KEY"
-    )
-    """The GitHub app private key. See
-    https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#generating-a-private-key
-    """
 
     enable_github_app: bool = Field(
         True, validation_alias="SEMAPHORE_ENABLE_GITHUB_APP"
@@ -85,6 +27,35 @@ class Config(BaseSettings):
     this configuration is automatically toggled to False. It also also be
     manually toggled to False if necessary.
     """
+
+    github_app_id: str | None = Field(
+        None, validation_alias="SEMAPHORE_GITHUB_APP_ID"
+    )
+    """The GitHub App ID, as determined by GitHub when setting up a GitHub
+    App.
+    """
+
+    github_app_private_key: SecretStr | None = Field(
+        None, validation_alias="SEMAPHORE_GITHUB_APP_PRIVATE_KEY"
+    )
+    """The GitHub app private key. See
+    https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#generating-a-private-key
+    """
+
+    github_webhook_secret: SecretStr | None = Field(
+        None, validation_alias="SEMAPHORE_GITHUB_WEBHOOK_SECRET"
+    )
+    """The GitHub app's webhook secret, as set when the App was created. See
+    https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks
+    """
+
+    log_level: LogLevel = Field(LogLevel.INFO, title="Log level")
+
+    log_profile: Profile = Field(Profile.production, title="Logging profile")
+
+    name: str = Field("semaphore", title="Name of application")
+
+    path_prefix: str = Field("/semaphore", title="URL prefix for application")
 
     phalanx_env: str = Field(..., validation_alias="SEMAPHORE_PHALANX_ENV")
     """Name of the Phalanx environment this Semaphore installation is running
@@ -97,11 +68,17 @@ class Config(BaseSettings):
     For a list of environments, see https://github.com/lsst-sqre/phalanx.
     """
 
+    slack_webhook: SecretStr | None = Field(
+        None,
+        title="Slack webhook for alerts",
+        description="If set, alerts will be posted to this Slack webhook",
+    )
+
     @field_validator(
         "github_webhook_secret", "github_app_private_key", mode="before"
     )
     @classmethod
-    def validate_none_secret(cls, v: SecretStr | None) -> SecretStr | None:
+    def validate_none_secret(cls, v: str | None) -> str | None:
         """Validate a SecretStr setting which may be "None" that is intended
         to be `None`.
 

--- a/src/semaphore/handlers/external/handlers.py
+++ b/src/semaphore/handlers/external/handlers.py
@@ -11,6 +11,7 @@ from gidgethub.sansio import Event
 from safir.dependencies.http_client import http_client_dependency
 from safir.dependencies.logger import logger_dependency
 from safir.metadata import get_metadata
+from safir.slack.webhook import SlackRouteErrorHandler
 from structlog.stdlib import BoundLogger
 
 from semaphore.broadcast.repository import BroadcastMessageRepository
@@ -21,9 +22,9 @@ from semaphore.github.webhooks import router as webhook_router
 
 from .models import Index
 
-__all__ = ["get_index", "post_github_webhook"]
+__all__ = ["router"]
 
-router = APIRouter(prefix=f"/{config.name}")
+router = APIRouter(route_class=SlackRouteErrorHandler)
 """FastAPI router for all external handlers.
 
 These routes have paths prefixed by the application name.
@@ -41,9 +42,7 @@ These routes have paths prefixed by the application name.
     response_model_exclude_none=True,
     tags=["internal"],
 )
-async def get_index(
-    logger: Annotated[BoundLogger, Depends(logger_dependency)],
-) -> Index:
+async def get_index() -> Index:
     """GET ``/semaphore/`` (the app's external root).
 
     This handler provides metadata and other top-level URLs, such as
@@ -54,15 +53,14 @@ async def get_index(
     internal root endpoint.
     """
     metadata = get_metadata(
-        package_name="semaphore",
-        application_name=config.name,
+        package_name="semaphore", application_name=config.name
     )
     return Index(
         metadata=metadata,
         github_app_id=config.github_app_id,
         github_app_enabled=config.enable_github_app,
-        api_docs_path=f"/{config.name}/docs",
-        openapi_path=f"/{config.name}/openapi.json",
+        api_docs_path=f"/{config.path_prefix}/docs",
+        openapi_path=f"/{config.path_prefix}/openapi.json",
     )
 
 

--- a/src/semaphore/handlers/internal/handlers.py
+++ b/src/semaphore/handlers/internal/handlers.py
@@ -7,12 +7,14 @@ receive web traffic from an ingress.
 
 from fastapi import APIRouter
 from safir.metadata import Metadata, get_metadata
+from safir.slack.webhook import SlackRouteErrorHandler
 
 from semaphore.config import config
 
-__all__ = ["get_index"]
+__all__ = ["router"]
 
-router = APIRouter()
+router = APIRouter(route_class=SlackRouteErrorHandler)
+"""FastAPI router for all internal handlers."""
 
 
 @router.get(

--- a/src/semaphore/handlers/v1/handlers.py
+++ b/src/semaphore/handlers/v1/handlers.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from safir.slack.webhook import SlackRouteErrorHandler
 
 from semaphore.broadcast.repository import BroadcastMessageRepository
-from semaphore.config import config
 from semaphore.dependencies.broadcastrepo import broadcast_repo_dependency
 
 from .models import BroadcastMessageModel
 
-router = APIRouter(prefix=f"/{config.name}/v1")
+router = APIRouter(route_class=SlackRouteErrorHandler)
 """FastAPI router for all v1 REST API endpoints."""
 
 

--- a/src/semaphore/main.py
+++ b/src/semaphore/main.py
@@ -12,8 +12,9 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from safir.dependencies.http_client import http_client_dependency
-from safir.logging import configure_logging
+from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
+from safir.slack.webhook import SlackRouteErrorHandler
 
 from .config import config
 from .dependencies.broadcastrepo import broadcast_repo_dependency
@@ -25,15 +26,14 @@ from .handlers.v1 import v1_router
 __all__ = ["app"]
 
 configure_logging(
-    profile=config.profile,
-    log_level=config.log_level,
-    name=config.logger_name,
+    profile=config.log_profile, log_level=config.log_level, name="semaphore"
 )
+configure_uvicorn_logging(config.log_level)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
-    logger = structlog.get_logger(config.logger_name)
+    logger = structlog.get_logger("semaphore")
     logger.info("Running startup")
 
     broadcast_repo = await broadcast_repo_dependency()
@@ -60,14 +60,14 @@ app = FastAPI(
         "(https://github.com/lsst-sqre/semaphore)"
     ),
     version=version("semaphore"),
-    docs_url=f"/{config.name}/docs",
-    redoc_url=f"/{config.name}/redoc",
-    openapi_url=f"/{config.name}/openapi.json",
+    docs_url=f"/{config.path_prefix}/docs",
+    redoc_url=f"/{config.path_prefix}/redoc",
+    openapi_url=f"/{config.path_prefix}/openapi.json",
     lifespan=lifespan,
 )
 app.include_router(internal_router)
-app.include_router(external_router)
-app.include_router(v1_router)
+app.include_router(external_router, prefix=config.path_prefix)
+app.include_router(v1_router, prefix=f"{config.path_prefix}/v1")
 app.add_middleware(XForwardedMiddleware)
 
 # This CORS policy is quite liberal. When the API becomes writeable we'll
@@ -79,6 +79,12 @@ app.add_middleware(
     allow_methods=["GET"],
     allow_headers=["*"],
 )
+
+# Configure Slack alerts.
+if webhook := config.slack_webhook:
+    logger = structlog.get_logger("semaphore")
+    SlackRouteErrorHandler.initialize(webhook, "semaphore", logger)
+    logger.debug("Initialized Slack webhook")
 
 
 def create_openapi() -> str:


### PR DESCRIPTION
Add support for reporting uncaught exceptions to Slack if a webhook is configured. Use the built-in Pydantic support for getting settings from environment variables rather than defining explicit validation aliases.

Rename `profile` to `log_profile` in the configuration, following the pattern in other applications.

Move the configuration of the route prefixes out of the handlers and into semaphore.main to match the current template.

Configure uvicorn logging so that all the logs will be in JSON format for Google Log Explorer.