### PR TITLE
DM-54797: Replace parse_timedelta with the Safir version

### DIFF
--- a/src/semaphore/broadcast/markdown.py
+++ b/src/semaphore/broadcast/markdown.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import datetime
 import enum
-import re
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Self
 
@@ -27,6 +26,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+from safir.pydantic import HumanTimedelta
 
 from .models import (
     BroadcastCategory,
@@ -51,25 +51,6 @@ front matter.
 
 See https://markdown-it-py.readthedocs.io/en/latest/using.html#the-parser
 """
-timespan_pattern = re.compile(
-    r"((?P<weeks>\d+?)\s*(weeks|week|w))?\s*"
-    r"((?P<days>\d+?)\s*(days|day|d))?\s*"
-    r"((?P<hours>\d+?)\s*(hours|hour|hr|h))?\s*"
-    r"((?P<minutes>\d+?)\s*(minutes|minute|mins|min|m))?\s*"
-    r"((?P<seconds>\d+?)\s*(seconds|second|secs|sec|s))?$"
-)
-"""Regular expression pattern for a time duration."""
-
-
-def parse_timedelta(text: str) -> datetime.timedelta:
-    """Parse a `datetime.timedelta` from a string containing integer numbers
-    of weeks, days, hours, minutes, and seconds.
-    """
-    m = timespan_pattern.match(text.strip())
-    if m is None:
-        raise ValueError(f"Could not parse a timespan from {text!r}.")
-    td_args = {k: int(v) for k, v in m.groupdict().items() if v is not None}
-    return datetime.timedelta(**td_args)
 
 
 class BroadcastMarkdown:
@@ -590,9 +571,7 @@ class BroadcastMarkdownFrontMatter(BaseModel):
     expire: arrow.Arrow | None = None
     """Date when the message expires."""
 
-    ttl: Annotated[
-        datetime.timedelta | None, PlainValidator(convert_to_timedelta)
-    ] = None
+    ttl: HumanTimedelta | None = None
     """Time duration if `expire` is not set with `defer`."""
 
     rules: list[RecurringRule] | None = None
@@ -741,25 +720,3 @@ def convert_to_arrow(
         return arrow.get(dt, default_tz)
     else:
         return arrow.get(dt, dateutil.tz.UTC)
-
-
-def convert_to_timedelta(v: Any) -> datetime.timedelta | None:
-    """Convert a value to a datetime.timedelta.
-
-    This function is intended to be used in a validator for Pydantic models,
-    and will raise ValueErrors or TypeErrors if ``v`` is not an appropriate
-    value.
-
-    Parameters
-    ----------
-    v
-        A value to convert into a timedelta.
-    """
-    if v is None:
-        return None
-    elif isinstance(v, str):
-        return parse_timedelta(v)
-    elif isinstance(v, datetime.timedelta):
-        return v
-    else:
-        raise TypeError(f"Cannot parse timedelta from {v!r}")

--- a/tests/broadcast/markdown_test.py
+++ b/tests/broadcast/markdown_test.py
@@ -14,7 +14,6 @@ from pydantic import ValidationError
 from semaphore.broadcast.markdown import (
     BroadcastMarkdown,
     BroadcastMarkdownFrontMatter,
-    parse_timedelta,
 )
 from semaphore.broadcast.models import (
     FixedExpirationScheduler,
@@ -26,44 +25,6 @@ from semaphore.broadcast.models import (
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        ("1w", datetime.timedelta(weeks=1)),
-        ("1week", datetime.timedelta(weeks=1)),
-        ("2weeks", datetime.timedelta(weeks=2)),
-        ("1d", datetime.timedelta(days=1)),
-        ("1day", datetime.timedelta(days=1)),
-        ("2days", datetime.timedelta(days=2)),
-        ("1h", datetime.timedelta(hours=1)),
-        ("1hr", datetime.timedelta(hours=1)),
-        ("1hour", datetime.timedelta(hours=1)),
-        ("1hours", datetime.timedelta(hours=1)),
-        ("1m", datetime.timedelta(minutes=1)),
-        ("1min", datetime.timedelta(minutes=1)),
-        ("1mins", datetime.timedelta(minutes=1)),
-        ("1minute", datetime.timedelta(minutes=1)),
-        ("1minutes", datetime.timedelta(minutes=1)),
-        ("1s", datetime.timedelta(seconds=1)),
-        ("1sec", datetime.timedelta(seconds=1)),
-        ("1secs", datetime.timedelta(seconds=1)),
-        ("1second", datetime.timedelta(seconds=1)),
-        ("1seconds", datetime.timedelta(seconds=1)),
-        ("1w1d1h1m", datetime.timedelta(weeks=1, days=1, hours=1, minutes=1)),
-        (
-            "1w 1d 1h 1m",
-            datetime.timedelta(weeks=1, days=1, hours=1, minutes=1),
-        ),
-        ("2days 6hr", datetime.timedelta(days=2, hours=6)),
-        ("1w 2d 6hours", datetime.timedelta(weeks=1, days=2, hours=6)),
-        ("1 week 2 days 6hours", datetime.timedelta(weeks=1, days=2, hours=6)),
-    ],
-)
-def test_parse_timedelta(value: str, expected: datetime.timedelta) -> None:
-    td = parse_timedelta(value)
-    assert td == expected
 
 
 def test_evergreen(broadcasts_dir: Path) -> None:


### PR DESCRIPTION
Safir now provides `parse_timedelta`, so there is no need for Semaphore to have its own copy and test suite.