### PR TITLE
DM-54797: Use Self types

### DIFF
--- a/src/semaphore/github/broadcastservices.py
+++ b/src/semaphore/github/broadcastservices.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import AsyncIterator, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 from gidgethub import GitHubException, RateLimitExceeded
 from gidgethub.sansio import accept_format
@@ -54,7 +54,7 @@ class GitHubMessageRef:
     """Git ref (e.g. ``refs/heads/main``)"""
 
     @classmethod
-    def from_push_event(cls, *, path: str, event: Event) -> GitHubMessageRef:
+    def from_push_event(cls, *, path: str, event: Event) -> Self:
         return cls(
             path=path,
             repo_name=event.data["repository"]["name"],

--- a/src/semaphore/handlers/v1/models.py
+++ b/src/semaphore/handlers/v1/models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Self
+
 from markdown_it import MarkdownIt
 from pydantic import BaseModel, Field
 
@@ -16,7 +18,7 @@ class FormattedText(BaseModel):
     html: str = Field(title="The HTML-formatted text.")
 
     @classmethod
-    def from_gfm(cls, gfm_text: str, *, inline: bool = False) -> FormattedText:
+    def from_gfm(cls, gfm_text: str, *, inline: bool = False) -> Self:
         """Create formatted text from GitHub-flavored markdown.
 
         Parameters
@@ -73,9 +75,7 @@ class BroadcastMessageModel(BaseModel):
     category: BroadcastCategory = Field(title="Category of the message.")
 
     @classmethod
-    def from_broadcast_message(
-        cls, message: BroadcastMessage
-    ) -> BroadcastMessageModel:
+    def from_broadcast_message(cls, message: BroadcastMessage) -> Self:
         """Create a v1 API BroadcastMessageModel from a broadcast message
         domain model.
 


### PR DESCRIPTION
For class methods returning their type, use `Self` types instead of the type where the method is defined.