### PR TITLE
DM-54797: Use relative imports for internal code

### DIFF
--- a/src/semaphore/dependencies/broadcastrepo.py
+++ b/src/semaphore/dependencies/broadcastrepo.py
@@ -3,7 +3,7 @@
 This FastAPI dependency provides a repository to request handlers.
 """
 
-from semaphore.broadcast.repository import BroadcastMessageRepository
+from ..broadcast.repository import BroadcastMessageRepository
 
 __all__ = ["BroadcastRepoDependency", "broadcast_repo_dependency"]
 

--- a/src/semaphore/github/broadcastservices.py
+++ b/src/semaphore/github/broadcastservices.py
@@ -10,9 +10,8 @@ from typing import TYPE_CHECKING, Any, Self
 from gidgethub import GitHubException, RateLimitExceeded
 from gidgethub.sansio import accept_format
 
-from semaphore.broadcast.markdown import BroadcastMarkdown
-from semaphore.config import config
-
+from ..broadcast.markdown import BroadcastMarkdown
+from ..config import config
 from .client import (
     create_github_client,
     create_github_installation_client,

--- a/src/semaphore/github/client.py
+++ b/src/semaphore/github/client.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import gidgethub.apps
 from gidgethub.httpx import GitHubAPI
 
-from semaphore.config import config
+from ..config import config
 
 if TYPE_CHECKING:
     import httpx.AsyncClient

--- a/src/semaphore/handlers/external/handlers.py
+++ b/src/semaphore/handlers/external/handlers.py
@@ -14,12 +14,11 @@ from safir.metadata import get_metadata
 from safir.slack.webhook import SlackRouteErrorHandler
 from structlog.stdlib import BoundLogger
 
-from semaphore.broadcast.repository import BroadcastMessageRepository
-from semaphore.config import config
-from semaphore.dependencies.broadcastrepo import broadcast_repo_dependency
-from semaphore.github.client import create_github_installation_client
-from semaphore.github.webhooks import router as webhook_router
-
+from ...broadcast.repository import BroadcastMessageRepository
+from ...config import config
+from ...dependencies.broadcastrepo import broadcast_repo_dependency
+from ...github.client import create_github_installation_client
+from ...github.webhooks import router as webhook_router
 from .models import Index
 
 __all__ = ["router"]

--- a/src/semaphore/handlers/v1/handlers.py
+++ b/src/semaphore/handlers/v1/handlers.py
@@ -7,9 +7,8 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 from safir.slack.webhook import SlackRouteErrorHandler
 
-from semaphore.broadcast.repository import BroadcastMessageRepository
-from semaphore.dependencies.broadcastrepo import broadcast_repo_dependency
-
+from ...broadcast.repository import BroadcastMessageRepository
+from ...dependencies.broadcastrepo import broadcast_repo_dependency
 from .models import BroadcastMessageModel
 
 router = APIRouter(route_class=SlackRouteErrorHandler)

--- a/src/semaphore/handlers/v1/models.py
+++ b/src/semaphore/handlers/v1/models.py
@@ -7,7 +7,7 @@ from typing import Self
 from markdown_it import MarkdownIt
 from pydantic import BaseModel, Field
 
-from semaphore.broadcast.models import BroadcastCategory, BroadcastMessage
+from ...broadcast.models import BroadcastCategory, BroadcastMessage
 
 
 class FormattedText(BaseModel):


### PR DESCRIPTION
Use relative imports for all code internal to Semaphore, following our current coding style.