### PR TITLE
DM-54797: Change AsyncIterator to AsyncGenerator

### DIFF
--- a/src/semaphore/github/broadcastservices.py
+++ b/src/semaphore/github/broadcastservices.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 
@@ -324,7 +324,7 @@ async def bootstrap_broadcast_repo(
 
 async def iter_installations(
     *, github_client: GitHubAPI, jwt: str
-) -> AsyncIterator[dict[str, Any]]:
+) -> AsyncGenerator[dict[str, Any]]:
     """Iterate over the GitHub app installations.
 
     Parameters
@@ -350,7 +350,7 @@ async def iter_installations(
 async def iter_installation_repositories(
     *,
     github_client: GitHubAPI,
-) -> AsyncIterator[dict[str, Any]]:
+) -> AsyncGenerator[dict[str, Any]]:
     """Iterate over repositories that the GitHub app installation has access
     to.
 
@@ -377,7 +377,7 @@ async def iter_installation_repositories(
 
 async def iter_repo_dir_contents(
     github_client: GitHubAPI, contents_url: str, directory_path: str
-) -> AsyncIterator[dict[str, Any]]:
+) -> AsyncGenerator[dict[str, Any]]:
     """Iterate over content objects in a repository in a GitHub repository.
 
     Parameters

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,13 +13,13 @@ from httpx import ASGITransport, AsyncClient
 from semaphore import main
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncGenerator
 
     from fastapi import FastAPI
 
 
 @pytest_asyncio.fixture
-async def app() -> AsyncIterator[FastAPI]:
+async def app() -> AsyncGenerator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
@@ -30,7 +30,7 @@ async def app() -> AsyncIterator[FastAPI]:
 
 
 @pytest_asyncio.fixture
-async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
+async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app."""
     async with AsyncClient(
         transport=ASGITransport(app), base_url="https://example.com/"


### PR DESCRIPTION
These types are not exactly the same, and async functions that call yield are technically generators, not iterators, because they have an `aclose` function.