### PR TITLE
DM-54797: Update pyproject.toml license information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,19 +2,20 @@
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 name = "semaphore"
 description = "Semaphore is the user messaging system for the Rubin Science Platform."
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 keywords = ["rubin", "lsst"]
 # https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.14",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
+    "Private :: Do Not Upload",
     "Typing :: Typed",
 ]
 requires-python = ">=3.14"


### PR DESCRIPTION
Use the new syntax for specifying the license in `pyproject.toml`. Also add the classifier blocking uploads to PyPI, since this is an application that shouldn't be uploaded as a module.