### PR TITLE
DM-54797: Add script to update uv version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ env:
   # Current supported uv version. The uv documentation recommends pinning
   # this. The version should match the version used in .pre-commit-config.yaml
   # and frozen in uv.lock. It is updated by make update-deps.
-  UV_VERSION: "0.11.3"
+  UV_VERSION: "0.11.8"
 
 "on":
   merge_group: {}

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -9,7 +9,7 @@ env:
   # Current supported uv version. The uv documentation recommends pinning
   # this. The version should match the version used in .pre-commit-config.yaml
   # and frozen in uv.lock. It is updated by make update-deps.
-  UV_VERSION: "0.11.3"
+  UV_VERSION: "0.11.8"
 
 "on":
   schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 FROM base-image AS install-image
 
 # Install uv.
-COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /bin/uv
 
 # Install some additional packages required for building dependencies.
 COPY scripts/install-dependency-packages.sh .

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,4 @@ update: update-deps init
 update-deps:
 	uv lock --upgrade
 	uv run --only-group=lint pre-commit autoupdate
+	./scripts/update-uv-version.sh

--- a/scripts/update-uv-version.sh
+++ b/scripts/update-uv-version.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Update uv version references based on the frozen version from uv.lock.
+
+# Bash "strict mode", to help catch problems and bugs in the shell script.
+# Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
+set -euo pipefail
+
+# Determine the current frozen uv version. Since the lint group depends on
+# pre-commit-uv, uv should always be part of its dependencies and thus updated
+# when running uv lock --upgrade, which should be run before this script.
+uv_version=$(uv export -q --no-hashes --only-group lint \
+             | grep ^uv== | sed 's/.*=//')
+
+# Replace the version in the env variables in GitHub Actions workflows.
+for f in .github/workflows/*.yaml; do
+    sed "s/UV_VERSION: .*/UV_VERSION: \"$uv_version\"/" "$f" >"$f.n"
+    if ! cmp -s "$f" "${f}.n"; then
+        echo "Updating UV_VERSION to $uv_version in $f"
+        mv "${f}.n" "$f"
+    else
+        rm "${f}.n"
+    fi
+done
+
+# Replace the version in any Dockerfiles.
+for f in Dockerfile*; do
+    sed "s/uv:[0-9][0-9.]*/uv:$uv_version/" "$f" >"${f}.n"
+    if ! cmp -s "$f" "${f}.n"; then
+        echo "Updating uv container version to $uv_version in $f"
+        mv "${f}.n" "$f"
+    else
+        rm "${f}.n"
+    fi
+done


### PR DESCRIPTION
Add the script from the FastAPI Safir app project template to automatically update the uv version in `Dockerfile` and GitHub Actions, and run it from the `update-deps` make target.