### PR TITLE
DM-54797: Simplify and merge imports

### DIFF
--- a/src/semaphore/broadcast/markdown.py
+++ b/src/semaphore/broadcast/markdown.py
@@ -2,12 +2,10 @@
 front matter.
 """
 
-from __future__ import annotations
-
 import datetime
 import enum
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Self
+from typing import Annotated, Any, Literal, Self
 
 import arrow
 import dateutil
@@ -15,6 +13,7 @@ import dateutil.parser
 import dateutil.rrule
 import yaml
 from markdown_it import MarkdownIt
+from markdown_it.token import Token
 from mdformat.renderer import MDRenderer
 from mdit_py_plugins.front_matter import front_matter_plugin
 from pydantic import (
@@ -36,12 +35,8 @@ from .models import (
     OpenEndedScheduler,
     PermaScheduler,
     RecurringScheduler,
+    Scheduler,
 )
-
-if TYPE_CHECKING:
-    from markdown_it.token import Token
-
-    from .models import Scheduler
 
 __all__ = ["BroadcastMarkdown", "BroadcastMarkdownFrontMatter"]
 
@@ -53,183 +48,73 @@ See https://markdown-it-py.readthedocs.io/en/latest/using.html#the-parser
 """
 
 
-class BroadcastMarkdown:
-    """A representation of a markdown file containing broadcast message
-    content and metadata.
+def convert_to_tzinfo(v: Any) -> datetime.tzinfo:
+    """Convert a value to a datetime.tzinfo.
 
-    Properties
+    This function is intended to be used in a validator for Pydantic models
+    and will raise ValueError or TypeError if ``v`` is not an appropriate
+    value.
+
+    Parameters
     ----------
-    text
-        The content of the markdown message (including YAML-formatted
-        front-matter).
-    identifier
-        A unique identifier that is associated with the markdown content.
+    v
+        A value to convert into a timezone.
     """
+    if isinstance(v, datetime.tzinfo):
+        return v
+    elif isinstance(v, str):
+        tz = dateutil.tz.gettz(v)
+        if not isinstance(tz, datetime.tzinfo):
+            raise TypeError(f"Could not parse timezone from {v!s}")
+        return tz
+    else:
+        raise TypeError(f"Incorrect type for timezone, got {v!r}.")
 
-    def __init__(self, text: str, identifier: str) -> None:
-        self._text = text
-        self.identifier = identifier
-        self._md_env: dict[Any, Any] = {}
-        self._md_tokens = md.parse(text, self._md_env)
-        self._metadata = self._parse_metadata()
 
-    def _parse_metadata(self) -> BroadcastMarkdownFrontMatter:
-        frontmatter_token = self._get_front_matter_token()
-        yaml_data = yaml.safe_load(frontmatter_token.content)
-        return BroadcastMarkdownFrontMatter.model_validate(yaml_data)
+def convert_to_arrow(
+    v: Any, default_tz: Any | None = None
+) -> arrow.Arrow | None:
+    """Convert a value to an arrow.Arrow datetime.
 
-    def _get_front_matter_token(self) -> Token:
-        for token in self._md_tokens:
-            if token.type == "front_matter":
-                return token
-        raise ValueError(
-            "A front_matter token is not present in the markdown content."
-        )
+    This function is intended to be used in a validator for Pydantic models,
+    and will raise ValueErrors or TypeErrors if ``v`` is not an appropriate
+    value.
 
-    @property
-    def metadata(self) -> BroadcastMarkdownFrontMatter:
-        """The broadcast's metadata."""
-        return self._metadata
+    Parameters
+    ----------
+    v
+        A value to convert into a datetime.
+    default_tz
+        A default timezone. If neither ``v`` has a timezone or ``default_tz``
+        is set, the default timezone is UTC.
+    """
+    if v is None:
+        return None
+    if isinstance(v, datetime.date):
+        # Pydantic pre-parses YYYY-MM-DD into a datetime.date even if
+        # we didn't declare the field as a datetime.date type
+        dt = datetime.datetime.combine(v, datetime.time())
+    elif isinstance(v, datetime.datetime):
+        # Pydantic pre-parses timestamps into datetime.datetime even if
+        # we didn't declare the field as a datetime.datetime type
+        # Pydantic pre-parses into a datetime
+        dt = v
+    elif isinstance(v, str):
+        try:
+            dt = dateutil.parser.parse(v, fuzzy=True, yearfirst=True)
+        except (ValueError, OverflowError) as e:
+            raise ValueError("Could not parse date") from e
+    else:
+        raise TypeError(f"Not a string (got {v!r})")
 
-    @property
-    def text(self) -> str:
-        """The full text of the markdown message (including front-matter)."""
-        return self._text
-
-    @property
-    def body(self) -> str | None:
-        """The text of the markdown body or `None` if the message doesn't have
-        body content.
-        """
-        body_tokens = [t for t in self._md_tokens if t.type != "front_matter"]
-        if len(body_tokens) == 0:
-            return None
-        else:
-            return MDRenderer().render(body_tokens, md.options, self._md_env)
-
-    def is_relevant_to_env(self, env_name: str) -> bool:
-        """Determine if this broadcast message is relevant to the given
-        Phalanx environment name given the ``env`` key in the front matter.
-
-        A message is considered "relevant" if the message's ``env`` key isn't
-        set (`None`) or if the given environment is in the list of
-        environment names.
-
-        Parameters
-        ----------
-        env_name
-            Name of the Phalanx environment (e.g., `idf-prod`).
-
-        Returns
-        -------
-        bool
-            `True`, if the message should be included in that environment's
-            broadcast message. `False` otherwise.
-        """
-        return (self._metadata.env is None) or (env_name in self._metadata.env)
-
-    def extract_content(self, *, get_summary: bool) -> str | None:
-        if self.body is None:
-            raise RuntimeError("No body provided")
-
-        paragraphs = self.body.split("\n\n")
-        new_summary = paragraphs[0]
-
-        del paragraphs[0]
-        new_body = "\n\n".join(paragraphs)
-
-        if get_summary:
-            return new_summary
-        else:
-            return new_body
-
-    @property
-    def extracted_summary(self) -> str:
-        content = self.extract_content(get_summary=True)
-
-        if content is None:
-            raise RuntimeError("No summary found")
-
-        return content
-
-    @property
-    def extracted_body(self) -> str | None:
-        content = self.extract_content(get_summary=False)
-
-        if content == "":
-            return None
-        else:
-            return content
-
-    def to_broadcast(self) -> BroadcastMessage:
-        """Export a BroadcastMessage from the markdown content.
-
-        Returns
-        -------
-        `semaphore.broadcast.data.BroadcastMessage`
-            The broadcast message.
-        """
-        if self.body is not None and self.metadata.summary is None:
-            new_summary = self.extracted_summary
-
-            new_body = self.extracted_body
-        else:
-            if self.metadata.summary is None:
-                raise RuntimeError(
-                    "Summary metadata must be set if body is empty"
-                )
-
-            new_summary = self.metadata.summary
-
-            new_body = self.body
-
-        return BroadcastMessage(
-            identifier=self.identifier,
-            summary_md=new_summary,
-            body_md=new_body,
-            scheduler=self._make_scheduler(),
-            enabled=self.metadata.enabled,
-            category=self.metadata.category,
-        )
-
-    def _make_ruleset(
-        self, rules: list[RecurringRule]
-    ) -> dateutil.rrule.rruleset:
-        rset = dateutil.rrule.rruleset(cache=True)
-        for rule in rules:
-            if rule.date is not None:
-                if rule.exclude:
-                    rset.exdate(rule.to_datetime())
-                else:
-                    rset.rdate(rule.to_datetime())
-            elif isinstance(rule, RecurringRule):
-                if rule.exclude:
-                    rset.exrule(rule.to_rrule())
-                else:
-                    rset.rrule(rule.to_rrule())
-        return rset
-
-    def _make_scheduler(self) -> Scheduler:
-        if self.metadata.defer is not None:
-            if self.metadata.expire is not None:
-                return OneTimeScheduler(
-                    self.metadata.defer, self.metadata.expire
-                )
-            elif self.metadata.ttl is not None:
-                return OneTimeScheduler.from_ttl(
-                    self.metadata.defer, self.metadata.ttl
-                )
-            else:
-                return OpenEndedScheduler(self.metadata.defer)
-        elif self.metadata.expire is not None:
-            # In this case, there is an expiration, but the defer must be
-            # none, so it is a fixed-expiration scheduler
-            return FixedExpirationScheduler(self.metadata.expire)
-        elif self.metadata.rules is not None and self.metadata.ttl is not None:
-            rset = self._make_ruleset(self.metadata.rules)
-            return RecurringScheduler(rruleset=rset, ttl=self.metadata.ttl)
-        else:
-            return PermaScheduler()
+    if dt.tzinfo:
+        # Parsed date includes a timezone.
+        return arrow.get(dt)
+    # naive datetime, so default to given timezone
+    elif default_tz:
+        return arrow.get(dt, default_tz)
+    else:
+        return arrow.get(dt, dateutil.tz.UTC)
 
 
 class FreqEnum(enum.StrEnum):
@@ -653,70 +538,180 @@ class BroadcastMarkdownFrontMatter(BaseModel):
         return self
 
 
-def convert_to_tzinfo(v: Any) -> datetime.tzinfo:
-    """Convert a value to a datetime.tzinfo.
+class BroadcastMarkdown:
+    """A representation of a markdown file containing broadcast message
+    content and metadata.
 
-    This function is intended to be used in a validator for Pydantic models
-    and will raise ValueError or TypeError if ``v`` is not an appropriate
-    value.
-
-    Parameters
+    Properties
     ----------
-    v
-        A value to convert into a timezone.
+    text
+        The content of the markdown message (including YAML-formatted
+        front-matter).
+    identifier
+        A unique identifier that is associated with the markdown content.
     """
-    if isinstance(v, datetime.tzinfo):
-        return v
-    elif isinstance(v, str):
-        tz = dateutil.tz.gettz(v)
-        if not isinstance(tz, datetime.tzinfo):
-            raise TypeError(f"Could not parse timezone from {v!s}")
-        return tz
-    else:
-        raise TypeError(f"Incorrect type for timezone, got {v!r}.")
 
+    def __init__(self, text: str, identifier: str) -> None:
+        self._text = text
+        self.identifier = identifier
+        self._md_env: dict[Any, Any] = {}
+        self._md_tokens = md.parse(text, self._md_env)
+        self._metadata = self._parse_metadata()
 
-def convert_to_arrow(
-    v: Any, default_tz: Any | None = None
-) -> arrow.Arrow | None:
-    """Convert a value to an arrow.Arrow datetime.
+    def _parse_metadata(self) -> BroadcastMarkdownFrontMatter:
+        frontmatter_token = self._get_front_matter_token()
+        yaml_data = yaml.safe_load(frontmatter_token.content)
+        return BroadcastMarkdownFrontMatter.model_validate(yaml_data)
 
-    This function is intended to be used in a validator for Pydantic models,
-    and will raise ValueErrors or TypeErrors if ``v`` is not an appropriate
-    value.
+    def _get_front_matter_token(self) -> Token:
+        for token in self._md_tokens:
+            if token.type == "front_matter":
+                return token
+        raise ValueError(
+            "A front_matter token is not present in the markdown content."
+        )
 
-    Parameters
-    ----------
-    v
-        A value to convert into a datetime.
-    default_tz
-        A default timezone. If neither ``v`` has a timezone or ``default_tz``
-        is set, the default timezone is UTC.
-    """
-    if v is None:
-        return None
-    if isinstance(v, datetime.date):
-        # Pydantic pre-parses YYYY-MM-DD into a datetime.date even if
-        # we didn't declare the field as a datetime.date type
-        dt = datetime.datetime.combine(v, datetime.time())
-    elif isinstance(v, datetime.datetime):
-        # Pydantic pre-parses timestamps into datetime.datetime even if
-        # we didn't declare the field as a datetime.datetime type
-        # Pydantic pre-parses into a datetime
-        dt = v
-    elif isinstance(v, str):
-        try:
-            dt = dateutil.parser.parse(v, fuzzy=True, yearfirst=True)
-        except (ValueError, OverflowError) as e:
-            raise ValueError("Could not parse date") from e
-    else:
-        raise TypeError(f"Not a string (got {v!r})")
+    @property
+    def metadata(self) -> BroadcastMarkdownFrontMatter:
+        """The broadcast's metadata."""
+        return self._metadata
 
-    if dt.tzinfo:
-        # Parsed date includes a timezone.
-        return arrow.get(dt)
-    # naive datetime, so default to given timezone
-    elif default_tz:
-        return arrow.get(dt, default_tz)
-    else:
-        return arrow.get(dt, dateutil.tz.UTC)
+    @property
+    def text(self) -> str:
+        """The full text of the markdown message (including front-matter)."""
+        return self._text
+
+    @property
+    def body(self) -> str | None:
+        """The text of the markdown body or `None` if the message doesn't have
+        body content.
+        """
+        body_tokens = [t for t in self._md_tokens if t.type != "front_matter"]
+        if len(body_tokens) == 0:
+            return None
+        else:
+            return MDRenderer().render(body_tokens, md.options, self._md_env)
+
+    def is_relevant_to_env(self, env_name: str) -> bool:
+        """Determine if this broadcast message is relevant to the given
+        Phalanx environment name given the ``env`` key in the front matter.
+
+        A message is considered "relevant" if the message's ``env`` key isn't
+        set (`None`) or if the given environment is in the list of
+        environment names.
+
+        Parameters
+        ----------
+        env_name
+            Name of the Phalanx environment (e.g., `idf-prod`).
+
+        Returns
+        -------
+        bool
+            `True`, if the message should be included in that environment's
+            broadcast message. `False` otherwise.
+        """
+        return (self._metadata.env is None) or (env_name in self._metadata.env)
+
+    def extract_content(self, *, get_summary: bool) -> str | None:
+        if self.body is None:
+            raise RuntimeError("No body provided")
+
+        paragraphs = self.body.split("\n\n")
+        new_summary = paragraphs[0]
+
+        del paragraphs[0]
+        new_body = "\n\n".join(paragraphs)
+
+        if get_summary:
+            return new_summary
+        else:
+            return new_body
+
+    @property
+    def extracted_summary(self) -> str:
+        content = self.extract_content(get_summary=True)
+
+        if content is None:
+            raise RuntimeError("No summary found")
+
+        return content
+
+    @property
+    def extracted_body(self) -> str | None:
+        content = self.extract_content(get_summary=False)
+
+        if content == "":
+            return None
+        else:
+            return content
+
+    def to_broadcast(self) -> BroadcastMessage:
+        """Export a BroadcastMessage from the markdown content.
+
+        Returns
+        -------
+        `semaphore.broadcast.data.BroadcastMessage`
+            The broadcast message.
+        """
+        if self.body is not None and self.metadata.summary is None:
+            new_summary = self.extracted_summary
+
+            new_body = self.extracted_body
+        else:
+            if self.metadata.summary is None:
+                raise RuntimeError(
+                    "Summary metadata must be set if body is empty"
+                )
+
+            new_summary = self.metadata.summary
+
+            new_body = self.body
+
+        return BroadcastMessage(
+            identifier=self.identifier,
+            summary_md=new_summary,
+            body_md=new_body,
+            scheduler=self._make_scheduler(),
+            enabled=self.metadata.enabled,
+            category=self.metadata.category,
+        )
+
+    def _make_ruleset(
+        self, rules: list[RecurringRule]
+    ) -> dateutil.rrule.rruleset:
+        rset = dateutil.rrule.rruleset(cache=True)
+        for rule in rules:
+            if rule.date is not None:
+                if rule.exclude:
+                    rset.exdate(rule.to_datetime())
+                else:
+                    rset.rdate(rule.to_datetime())
+            elif isinstance(rule, RecurringRule):
+                if rule.exclude:
+                    rset.exrule(rule.to_rrule())
+                else:
+                    rset.rrule(rule.to_rrule())
+        return rset
+
+    def _make_scheduler(self) -> Scheduler:
+        if self.metadata.defer is not None:
+            if self.metadata.expire is not None:
+                return OneTimeScheduler(
+                    self.metadata.defer, self.metadata.expire
+                )
+            elif self.metadata.ttl is not None:
+                return OneTimeScheduler.from_ttl(
+                    self.metadata.defer, self.metadata.ttl
+                )
+            else:
+                return OpenEndedScheduler(self.metadata.defer)
+        elif self.metadata.expire is not None:
+            # In this case, there is an expiration, but the defer must be
+            # none, so it is a fixed-expiration scheduler
+            return FixedExpirationScheduler(self.metadata.expire)
+        elif self.metadata.rules is not None and self.metadata.ttl is not None:
+            rset = self._make_ruleset(self.metadata.rules)
+            return RecurringScheduler(rruleset=rset, ttl=self.metadata.ttl)
+        else:
+            return PermaScheduler()

--- a/src/semaphore/broadcast/models.py
+++ b/src/semaphore/broadcast/models.py
@@ -1,18 +1,13 @@
 """Domain models for broadcast messages."""
 
-from __future__ import annotations
-
 import datetime
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, cast, override
+from typing import cast, override
 
 import arrow
-
-if TYPE_CHECKING:
-    import dateutil.rrule
-
+import dateutil.rrule
 
 __all__ = [
     "BroadcastCategory",

--- a/src/semaphore/broadcast/repository.py
+++ b/src/semaphore/broadcast/repository.py
@@ -1,12 +1,8 @@
 """Broadcast message repository."""
 
-from __future__ import annotations
-
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from .models import BroadcastMessage
+from .models import BroadcastMessage
 
 
 class NotFoundError(Exception):

--- a/src/semaphore/config.py
+++ b/src/semaphore/config.py
@@ -1,7 +1,5 @@
 """Configuration for Semaphore."""
 
-from __future__ import annotations
-
 from typing import Self
 
 from pydantic import Field, SecretStr, field_validator, model_validator

--- a/src/semaphore/github/broadcastservices.py
+++ b/src/semaphore/github/broadcastservices.py
@@ -1,30 +1,24 @@
 """Orchestration around GitHub repository sources for broadcast messages."""
 
-from __future__ import annotations
-
 import dataclasses
 from collections.abc import AsyncGenerator, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Self
+from typing import Any, Self
 
+import httpx
 from gidgethub import GitHubException, RateLimitExceeded
-from gidgethub.sansio import accept_format
+from gidgethub.httpx import GitHubAPI
+from gidgethub.sansio import Event, accept_format
+from structlog.stdlib import BoundLogger
 
 from ..broadcast.markdown import BroadcastMarkdown
+from ..broadcast.repository import BroadcastMessageRepository
 from ..config import config
 from .client import (
     create_github_client,
     create_github_installation_client,
     get_app_jwt,
 )
-
-if TYPE_CHECKING:
-    import httpx
-    from gidgethub.httpx import GitHubAPI
-    from gidgethub.sansio import Event
-    from sempaphore.broadcast.repository import BroadcastMessageRepository
-    from structlog.stdlib import BoundLogger
-
 
 BROADCASTS_DIR = "broadcasts"
 """Directory relative to a GitHub repository's root that contains broadcast

--- a/src/semaphore/github/client.py
+++ b/src/semaphore/github/client.py
@@ -2,17 +2,11 @@
 configuration.
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 import gidgethub.apps
 from gidgethub.httpx import GitHubAPI
+from httpx import AsyncClient
 
 from ..config import config
-
-if TYPE_CHECKING:
-    import httpx.AsyncClient
 
 __all__ = [
     "GitHubClientConfigError",
@@ -61,7 +55,7 @@ def get_app_jwt() -> str:
 
 
 def create_github_client(
-    *, http_client: httpx.AsyncClient, oauth_token: str | None = None
+    *, http_client: AsyncClient, oauth_token: str | None = None
 ) -> GitHubAPI:
     """Create an HTTPx GitHub client.
 
@@ -84,7 +78,7 @@ def create_github_client(
 
 
 async def create_github_installation_client(
-    *, http_client: httpx.AsyncClient, installation_id: str
+    *, http_client: AsyncClient, installation_id: str
 ) -> GitHubAPI:
     """Create a GitHub API client authorized as a GitHub App installation,
     with specific permissions on the repository/organization the app is

--- a/src/semaphore/github/webhooks.py
+++ b/src/semaphore/github/webhooks.py
@@ -1,18 +1,14 @@
 """GitHub webhook event handlers."""
 
-from __future__ import annotations
+from typing import Any
 
-from typing import TYPE_CHECKING, Any
-
+from gidgethub.httpx import GitHubAPI
 from gidgethub.routing import Router
+from gidgethub.sansio import Event
+from structlog.stdlib import BoundLogger
 
+from ..broadcast.repository import BroadcastMessageRepository
 from .broadcastservices import update_broadcast_repo_from_push_event
-
-if TYPE_CHECKING:
-    from gidgethub.httpx import GitHubAPI
-    from gidgethub.sansio import Event
-    from sempaphore.broadcast.repository import BroadcastMessageRepository
-    from structlog.stdlib import BoundLogger
 
 __all__ = ["router"]
 

--- a/src/semaphore/handlers/external/handlers.py
+++ b/src/semaphore/handlers/external/handlers.py
@@ -1,7 +1,5 @@
 """Handlers for the app's external root, ``/semaphore/``."""
 
-from __future__ import annotations
-
 import asyncio
 from typing import Annotated
 

--- a/src/semaphore/handlers/v1/handlers.py
+++ b/src/semaphore/handlers/v1/handlers.py
@@ -1,7 +1,5 @@
 """Handlers for the app's v1 REST API."""
 
-from __future__ import annotations
-
 from typing import Annotated
 
 from fastapi import APIRouter, Depends

--- a/src/semaphore/handlers/v1/models.py
+++ b/src/semaphore/handlers/v1/models.py
@@ -1,7 +1,5 @@
 """Models for the v1 REST API."""
 
-from __future__ import annotations
-
 from typing import Self
 
 from markdown_it import MarkdownIt

--- a/src/semaphore/main.py
+++ b/src/semaphore/main.py
@@ -1,7 +1,5 @@
 """Semaphore FastAPI application."""
 
-from __future__ import annotations
-
 import json
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager

--- a/tests/broadcast/markdown_test.py
+++ b/tests/broadcast/markdown_test.py
@@ -1,10 +1,8 @@
 """Tests for the semaphore.broadcast.markdown module."""
 
-from __future__ import annotations
-
 import datetime
 from datetime import UTC
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import arrow
 import dateutil
@@ -22,9 +20,6 @@ from semaphore.broadcast.models import (
     PermaScheduler,
     RecurringScheduler,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_evergreen(broadcasts_dir: Path) -> None:

--- a/tests/broadcast/models_test.py
+++ b/tests/broadcast/models_test.py
@@ -1,7 +1,5 @@
 """Tests for the semaphore.broadcast.models module."""
 
-from __future__ import annotations
-
 import datetime
 
 import arrow

--- a/tests/broadcast/repository_test.py
+++ b/tests/broadcast/repository_test.py
@@ -1,7 +1,5 @@
 """Test the semaphore.broadcast.repository module."""
 
-from __future__ import annotations
-
 import pytest
 
 from semaphore.broadcast.repository import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,15 @@
 """Pytest fixtures."""
 
-from __future__ import annotations
-
+from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 import pytest_asyncio
 from asgi_lifespan import LifespanManager
+from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from semaphore import main
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
-
-    from fastapi import FastAPI
 
 
 @pytest_asyncio.fixture

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -1,15 +1,9 @@
 """Tests for the semaphore.handlers.external module and routes."""
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from semaphore.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -1,15 +1,9 @@
 """Tests for the semaphore.handlers.internal module and routes."""
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from semaphore.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/tests/handlers/v1_test.py
+++ b/tests/handlers/v1_test.py
@@ -1,17 +1,13 @@
 """Tests for the semaphore v1 API."""
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
+from httpx import AsyncClient
 
 from semaphore.dependencies.broadcastrepo import broadcast_repo_dependency
 
 from ..support.broadcasts import create_active_message, create_disabled_message
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 async def get_broadcasts(client: AsyncClient) -> dict[str, Any]:

--- a/tests/support/broadcasts.py
+++ b/tests/support/broadcasts.py
@@ -1,7 +1,5 @@
 """Test utilities for creating sample broadcasts."""
 
-from __future__ import annotations
-
 import arrow
 
 from semaphore.broadcast.models import (


### PR DESCRIPTION
Stop separating out the imports used only for type checking, since that tends to result in invalid imports that are silently ignored (and indeed, undoing this separation required fixing several typos that had prevented full type checking). Remove `from __future__ import annotations`, since it is deprecated in Python and is being slowly removed. Reorder some code to avoid forward references.