### PR TITLE
DM-54942: Fix Semaphore memory leak

### DIFF
--- a/src/semaphore/broadcast/markdown.py
+++ b/src/semaphore/broadcast/markdown.py
@@ -410,6 +410,7 @@ class RecurringRule(BaseModel):
             byhour=self.by_hour,
             byminute=self.by_minute,
             bysecond=self.by_second,
+            cache=False,
         )
 
     def to_datetime(self) -> datetime.datetime:
@@ -680,7 +681,7 @@ class BroadcastMarkdown:
     def _make_ruleset(
         self, rules: list[RecurringRule]
     ) -> dateutil.rrule.rruleset:
-        rset = dateutil.rrule.rruleset(cache=True)
+        rset = dateutil.rrule.rruleset(cache=False)
         for rule in rules:
             if rule.date is not None:
                 if rule.exclude:

--- a/src/semaphore/handlers/v1/models.py
+++ b/src/semaphore/handlers/v1/models.py
@@ -7,6 +7,9 @@ from pydantic import BaseModel, Field
 
 from ...broadcast.models import BroadcastCategory, BroadcastMessage
 
+_MD_PARSER = MarkdownIt("gfm-like")
+"""Global Markdown parser used for all rendering."""
+
 
 class FormattedText(BaseModel):
     """Text that is formatted in both markdown and HTML."""
@@ -31,11 +34,10 @@ class FormattedText(BaseModel):
         FormattedText
             The formatted text, containing both markdown and HTML renderings.
         """
-        md_parser = MarkdownIt("gfm-like")
         if inline:
-            html_text = md_parser.renderInline(gfm_text)
+            html_text = _MD_PARSER.renderInline(gfm_text)
         else:
-            html_text = md_parser.render(gfm_text)
+            html_text = _MD_PARSER.render(gfm_text)
         return cls(gfm=gfm_text, html=html_text)
 
 


### PR DESCRIPTION
Semaphore is leaking memory in idfdev. Disabling caching in dateutil and using a global `MarkdownIt` parser appears to help. These approaches were suggested by Claude Code.