### PR TITLE
DM-55229: Test user notification authorization

### DIFF
--- a/src/semaphore/exceptions.py
+++ b/src/semaphore/exceptions.py
@@ -11,3 +11,6 @@ class NotificationNotFoundError(ClientRequestError):
 
     error = "notification_not_found"
     status_code = status.HTTP_404_NOT_FOUND
+
+    def __init__(self, id: str) -> None:
+        super().__init__(f"Unknown notification: {id}")

--- a/src/semaphore/main.py
+++ b/src/semaphore/main.py
@@ -12,6 +12,7 @@ from fastapi.openapi.utils import get_openapi
 from safir.database import create_database_engine, is_database_current
 from safir.dependencies.db_session import db_session_dependency
 from safir.dependencies.http_client import http_client_dependency
+from safir.fastapi import ClientRequestError, client_request_error_handler
 from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
 from safir.sentry import initialize_sentry
@@ -83,9 +84,14 @@ app = FastAPI(
     openapi_url=f"{config.path_prefix}/openapi.json",
     lifespan=lifespan,
 )
+"""The main FastAPI web application for Semaphore."""
+
+# Attach the routers.
 app.include_router(internal_router)
 app.include_router(external_router, prefix=config.path_prefix)
 app.include_router(v1_router, prefix=f"{config.path_prefix}/v1")
+
+# Add middleware.
 app.add_middleware(XForwardedMiddleware)
 
 # This CORS policy is quite liberal. When the API becomes writeable we'll
@@ -97,6 +103,9 @@ app.add_middleware(
     allow_methods=["GET"],
     allow_headers=["*"],
 )
+
+# Add exception handlers.
+app.exception_handler(ClientRequestError)(client_request_error_handler)
 
 # Configure Slack alerts.
 if webhook := config.slack_webhook:

--- a/tests/handlers/v1_test.py
+++ b/tests/handlers/v1_test.py
@@ -95,3 +95,10 @@ async def test_user_notification(
     notification = r.json()
     data.assert_json_matches(notification, "api/notification-one")
     assert datetime.fromisoformat(notification["created"]) == created
+
+    # The admin user should not see the notification for the regular user.
+    r = await admin_client.get("/semaphore/v1/notifications")
+    assert r.status_code == 200
+    assert r.json() == []
+    r = await admin_client.get(notification_url)
+    assert r.status_code == 404


### PR DESCRIPTION
Add a test to ensure users cannot see each other's notifications, and fix handling of 404 exceptions for nonexistent notifications.