### PR TITLE
DM-55229: Add support for marking notifications read

### DIFF
--- a/src/semaphore/handlers/v1/handlers.py
+++ b/src/semaphore/handlers/v1/handlers.py
@@ -18,7 +18,7 @@ from ...models.notification import (
     UserNotificationSummary,
     UserNotificationWithUrl,
 )
-from .models import BroadcastMessageModel
+from .models import BroadcastMessageModel, UserNotificationRead
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
 """FastAPI router for all v1 REST API endpoints."""
@@ -125,6 +125,7 @@ async def admin_list_notifications(
     parsed_cursor = None
     if cursor:
         parsed_cursor = UserNotificationCursor.from_str(cursor)
+    base_url = context.request.url_for("admin_list_notifications")
     results = await service.list_unformatted(
         cursor=parsed_cursor,
         limit=limit,
@@ -132,7 +133,7 @@ async def admin_list_notifications(
         until=until,
         recipient=recipient,
         sender=sender,
-        base_url=context.request.url,
+        base_url=base_url,
     )
     if limit:
         response.headers["Link"] = results.link_header(context.request.url)
@@ -196,12 +197,13 @@ async def list_notifications(
     parsed_cursor = None
     if cursor:
         parsed_cursor = UserNotificationCursor.from_str(cursor)
+    base_url = context.request.url_for("list_notifications")
     results = await service.list_formatted(
         cursor=parsed_cursor,
         limit=limit,
         unread=unread,
         required_recipient=context.username,
-        base_url=context.request.url,
+        base_url=base_url,
     )
     if limit:
         response.headers["Link"] = results.link_header(context.request.url)
@@ -213,13 +215,33 @@ async def list_notifications(
     "/notifications/{id}",
     summary="Get admin notification",
     description="Retrieve a specific admin notification.",
-    tags=["admin", "notifications"],
+    tags=["notifications"],
 )
 async def get_notification(
     id: str,
     *,
     context: Annotated[RequestContext, Depends(context_dependency)],
-    response: Response,
 ) -> UserNotificationFormatted:
     service = context.factory.create_notification_service()
     return await service.get_formatted(id, context.username)
+
+
+@router.post(
+    "/notifications/read",
+    summary="Mark notifications read",
+    description=(
+        "Mark a list of notifications read. Notifications that do not exist"
+        " or that are already marked as read are silently ignored. Returning"
+        " errors for nonexistent notifications is not useful since there may"
+        " be race conditions with services revoking notifications."
+    ),
+    status_code=204,
+    tags=["notifications"],
+)
+async def post_notification_read(
+    read: UserNotificationRead,
+    *,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> None:
+    service = context.factory.create_notification_service()
+    await service.mark_read(read.ids, context.username)

--- a/src/semaphore/handlers/v1/models.py
+++ b/src/semaphore/handlers/v1/models.py
@@ -1,6 +1,6 @@
 """Models for the v1 REST API."""
 
-from typing import Self
+from typing import Annotated, Self
 
 from markdown_it import MarkdownIt
 from pydantic import BaseModel, Field
@@ -10,6 +10,7 @@ from ...broadcast.models import BroadcastCategory, BroadcastMessage
 __all__ = [
     "BroadcastMessageModel",
     "FormattedText",
+    "UserNotificationRead",
 ]
 
 _MD_PARSER = MarkdownIt("gfm-like")
@@ -107,3 +108,19 @@ class BroadcastMessageModel(BaseModel):
             stale=message.stale,
             category=message.category,
         )
+
+
+class UserNotificationRead(BaseModel):
+    """Notification IDs to mark as read."""
+
+    ids: Annotated[
+        set[str],
+        Field(
+            title="Notification IDs",
+            description=(
+                "These notifications will be marked as read at the current"
+                " time if they are not already marked as read."
+            ),
+            examples=[{"56", "57", "58", "59"}],
+        ),
+    ]

--- a/src/semaphore/main.py
+++ b/src/semaphore/main.py
@@ -65,6 +65,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     yield
 
+    await db_session_dependency.aclose()
     await http_client_dependency.aclose()
 
 

--- a/src/semaphore/models/notification.py
+++ b/src/semaphore/models/notification.py
@@ -61,7 +61,7 @@ class CreateUserNotification(BaseModel):
                 "You are using 448GiB of disk out of a quota of 500GiB."
             ],
         ),
-    ]
+    ] = None
 
 
 class UserNotificationBase(BaseModel):

--- a/src/semaphore/services/notification.py
+++ b/src/semaphore/services/notification.py
@@ -289,3 +289,21 @@ class UserNotificationService:
             prev_cursor=results.prev_cursor,
             count=results.count,
         )
+
+    async def mark_read(self, ids: set[str], required_recipient: str) -> None:
+        """Mark a set of notifications as read.
+
+        Notifications that are already marked as read will be silently left
+        unchanged, as will notifications that don't exist. Error reporting is
+        not useful here since there may be a race condition with revoking
+        notifications.
+
+        Parameters
+        ----------
+        ids
+            Notification IDs to mark as read.
+        required_recipient
+            Only operate on notifications sent to this username.
+        """
+        async with self._session.begin():
+            await self._storage.mark_read(required_recipient, ids)

--- a/src/semaphore/storage/notification.py
+++ b/src/semaphore/storage/notification.py
@@ -134,9 +134,30 @@ class UserNotificationStore:
         if sender:
             stmt = stmt.where(SQLUserNotification.sender == sender)
         if unread:
-            stmt = stmt.where(SQLUserNotification.read.isnot(None))
+            stmt = stmt.where(SQLUserNotification.read.is_(None))
 
         # Perform the paginated query.
         return await self._paginated_runner.query_object(
             self._session, stmt, cursor=cursor, limit=limit
         )
+
+    async def mark_read(self, recipient: str, ids: set[str]) -> None:
+        """Mark a set of notification IDs as read.
+
+        Parameters
+        ----------
+        recipient
+            Only act on notifications sent to this recipient.
+        ids
+            Set of IDs to mark as read.
+        """
+        ids_int = [int(v) for v in ids]
+        now = datetime_to_db(datetime.now(tz=UTC).replace(microsecond=0))
+        stmt = select(SQLUserNotification).where(
+            SQLUserNotification.recipient == recipient,
+            SQLUserNotification.id.in_(ids_int),
+            SQLUserNotification.read.is_(None),
+        )
+        notifications = await self._session.scalars(stmt)
+        for notification in notifications:
+            notification.read = now

--- a/tests/data/api/multiple.json
+++ b/tests/data/api/multiple.json
@@ -1,0 +1,32 @@
+[
+  {
+    "created": "<ANY>",
+    "id": "3",
+    "read": null,
+    "summary": {
+      "gfm": "Notification three",
+      "html": "Notification three"
+    },
+    "url": "https://example.com/semaphore/v1/notifications/3"
+  },
+  {
+    "created": "<ANY>",
+    "id": "2",
+    "read": null,
+    "summary": {
+      "gfm": "Notification two",
+      "html": "Notification two"
+    },
+    "url": "https://example.com/semaphore/v1/notifications/2"
+  },
+  {
+    "created": "<ANY>",
+    "id": "1",
+    "read": null,
+    "summary": {
+      "gfm": "Notification one",
+      "html": "Notification one"
+    },
+    "url": "https://example.com/semaphore/v1/notifications/1"
+  }
+]

--- a/tests/data/notifications/multiple.json
+++ b/tests/data/notifications/multiple.json
@@ -1,0 +1,14 @@
+[
+  {
+    "recipient": "some-user",
+    "summary": "Notification one"
+  },
+  {
+    "recipient": "some-user",
+    "summary": "Notification two"
+  },
+  {
+    "recipient": "some-user",
+    "summary": "Notification three"
+  }
+]

--- a/tests/handlers/v1_test.py
+++ b/tests/handlers/v1_test.py
@@ -2,9 +2,10 @@
 
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from unittest.mock import ANY
 
 import pytest
-from httpx import AsyncClient
+from httpx import AsyncClient, Response
 from safir.testing.data import Data
 
 from semaphore.dependencies.broadcastrepo import broadcast_repo_dependency
@@ -17,6 +18,19 @@ async def get_broadcasts(client: AsyncClient) -> dict[str, Any]:
     response = await client.get("/semaphore/v1/broadcasts")
     assert response.status_code == 200
     return response.json()
+
+
+def assert_http_response(r: Response, expected_status: int) -> None:
+    """Check that an HTTP response matches expectations.
+
+    Parameters
+    ----------
+    r
+        Response to check.
+    expected_status
+        Expected status code.
+    """
+    assert r.status_code == expected_status, f"Failed response body: {r.text}"
 
 
 @pytest.mark.asyncio
@@ -55,34 +69,34 @@ async def test_user_notification(
         "/semaphore/v1/admin/notifications",
         json=data.read_json("notifications/example"),
     )
-    assert r.status_code == 200
-    notification_url = r.headers["Location"]
+    assert_http_response(r, 200)
     sent = r.json()
     data.assert_json_matches(sent, "api/sent")
     created = datetime.fromisoformat(sent["created"])
     assert start <= created <= start + timedelta(seconds=2)
     message_id = sent["id"]
     expected_url = "semaphore/v1/admin/notifications"
+    notification_url = r.headers["Location"]
     assert notification_url == f"{TEST_BASE_URL}{expected_url}/{message_id}"
     assert sent["url"] == notification_url
 
     # Retrieve the sent notification. This should be the same but without the
     # url key.
     r = await admin_client.get(notification_url)
-    assert r.status_code == 200
+    assert_http_response(r, 200)
     assert r.json() == {k: v for k, v in sent.items() if k != "url"}
 
     # Retrieving the list of all admin notifications should return a list
     # containing just that notification.
     r = await admin_client.get("/semaphore/v1/admin/notifications")
-    assert r.status_code == 200
+    assert_http_response(r, 200)
     assert r.json() == [sent]
 
     # Retrieving messages for the recipient user should also retrieve a list
     # of message summaries containing that message, with the summary
     # formatted and a URL to the full message.
     r = await user_client.get("/semaphore/v1/notifications")
-    assert r.status_code == 200
+    assert_http_response(r, 200)
     notifications = r.json()
     data.assert_json_matches(notifications, "api/notifications")
     assert datetime.fromisoformat(notifications[0]["created"]) == created
@@ -91,14 +105,60 @@ async def test_user_notification(
     # include the full formatted body.
     notification_url = notifications[0]["url"]
     r = await user_client.get(notification_url)
-    assert r.status_code == 200
+    assert_http_response(r, 200)
     notification = r.json()
     data.assert_json_matches(notification, "api/notification-one")
     assert datetime.fromisoformat(notification["created"]) == created
 
     # The admin user should not see the notification for the regular user.
     r = await admin_client.get("/semaphore/v1/notifications")
-    assert r.status_code == 200
+    assert_http_response(r, 200)
     assert r.json() == []
     r = await admin_client.get(notification_url)
-    assert r.status_code == 404
+    assert_http_response(r, 404)
+
+
+@pytest.mark.asyncio
+async def test_user_notification_read(
+    data: Data, admin_client: AsyncClient, user_client: AsyncClient
+) -> None:
+    to_send = data.read_json("notifications/multiple")
+    for notification in to_send:
+        r = await admin_client.post(
+            "/semaphore/v1/admin/notifications",
+            json=notification,
+        )
+        assert_http_response(r, 200)
+
+    # Listing all unread notifications should return all three.
+    r = await user_client.get(
+        "/semaphore/v1/notifications", params={"unread": "true"}
+    )
+    assert_http_response(r, 200)
+    notifications = r.json()
+    data.assert_json_matches(notifications, "api/multiple")
+
+    # Mark the first two as read.
+    ids = {"ids": [notifications[0]["id"], notifications[1]["id"]]}
+    start = datetime.now(tz=UTC).replace(microsecond=0)
+    r = await user_client.post("/semaphore/v1/notifications/read", json=ids)
+    assert_http_response(r, 204)
+
+    # Now, listing all unread notifications returns only the third.
+    r = await user_client.get(
+        "/semaphore/v1/notifications", params={"unread": "true"}
+    )
+    assert_http_response(r, 200)
+    assert r.json() == notifications[2:]
+
+    # Listing all notifications still returns all three, but now with read
+    # timestamps.
+    r = await user_client.get("/semaphore/v1/notifications")
+    assert_http_response(r, 200)
+    updated_notifications = r.json()
+    notifications[0]["read"] = ANY
+    notifications[1]["read"] = ANY
+    assert updated_notifications == notifications
+    for index in (0, 1):
+        read = datetime.fromisoformat(updated_notifications[index]["read"])
+        assert start <= read <= start + timedelta(seconds=2)


### PR DESCRIPTION
Add the route that allows users to mark notifications as read. Fix several other bugs found when testing that:

- Allow the body of a notification to be omitted and make it default to null.
- Fix the URLs for notifications returned by list methods to not include any search parameters of the list call.
- Improve checking of HTTP return status to display the body on failure.
- Fix searches for unread notifications.
- Close down the database session when closing down the application.