### PR TITLE
DM-55229: Add search and pagination tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from safir.database import (
     stamp_database_async,
 )
 from safir.testing.data import Data
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from semaphore import main
 from semaphore.config import config
@@ -74,15 +75,20 @@ def data(request: pytest.FixtureRequest) -> Data:
 
 
 @pytest_asyncio.fixture
-async def empty_database() -> None:
+async def empty_database(engine: AsyncEngine) -> None:
     """Empty the database before a test."""
     logger = structlog.get_logger("semaphore")
-    engine = create_database_engine(
-        config.database_url, config.database_password
-    )
     base = SchemaBase.metadata
     await initialize_database(engine, logger, schema=base, reset=True)
     await stamp_database_async(engine)
+
+
+@pytest_asyncio.fixture
+async def engine() -> AsyncGenerator[AsyncEngine]:
+    engine = create_database_engine(
+        config.database_url, config.database_password
+    )
+    yield engine
     await engine.dispose()
 
 

--- a/tests/data/api/notifications-pagination.json
+++ b/tests/data/api/notifications-pagination.json
@@ -1,0 +1,22 @@
+[
+  {
+    "created": "2026-06-17T17:00:00Z",
+    "id": "2",
+    "read": null,
+    "summary": {
+      "gfm": "Notification two",
+      "html": "Notification two"
+    },
+    "url": "https://example.com/semaphore/v1/notifications/2"
+  },
+  {
+    "created": "2026-06-17T15:00:00Z",
+    "id": "1",
+    "read": null,
+    "summary": {
+      "gfm": "Notification one",
+      "html": "Notification one"
+    },
+    "url": "https://example.com/semaphore/v1/notifications/1"
+  }
+]

--- a/tests/data/api/sent-pagination.json
+++ b/tests/data/api/sent-pagination.json
@@ -1,0 +1,32 @@
+[
+  {
+    "body": null,
+    "created": "2026-06-17T18:00:00Z",
+    "id": "3",
+    "read": null,
+    "recipient": "other-user",
+    "sender": "admin",
+    "summary": "Notification three",
+    "url": "https://example.com/semaphore/v1/admin/notifications/3"
+  },
+  {
+    "body": null,
+    "created": "2026-06-17T17:00:00Z",
+    "id": "2",
+    "read": null,
+    "recipient": "some-user",
+    "sender": "admin",
+    "summary": "Notification two",
+    "url": "https://example.com/semaphore/v1/admin/notifications/2"
+  },
+  {
+    "body": null,
+    "created": "2026-06-17T15:00:00Z",
+    "id": "1",
+    "read": null,
+    "recipient": "some-user",
+    "sender": "admin",
+    "summary": "Notification one",
+    "url": "https://example.com/semaphore/v1/admin/notifications/1"
+  }
+]

--- a/tests/data/notifications/pagination.json
+++ b/tests/data/notifications/pagination.json
@@ -1,0 +1,14 @@
+[
+  {
+    "recipient": "some-user",
+    "summary": "Notification one"
+  },
+  {
+    "recipient": "some-user",
+    "summary": "Notification two"
+  },
+  {
+    "recipient": "other-user",
+    "summary": "Notification three"
+  }
+]

--- a/tests/handlers/v1_test.py
+++ b/tests/handlers/v1_test.py
@@ -6,9 +6,14 @@ from unittest.mock import ANY
 
 import pytest
 from httpx import AsyncClient, Response
+from safir.database import create_async_session, datetime_to_db
+from safir.http import PaginationLinkData
 from safir.testing.data import Data
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from semaphore.dependencies.broadcastrepo import broadcast_repo_dependency
+from semaphore.schema import UserNotification as SQLUserNotification
 
 from ..support.broadcasts import create_active_message, create_disabled_message
 from ..support.constants import TEST_BASE_URL
@@ -55,7 +60,7 @@ async def test_get_broadcasts(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_user_notification(
+async def test_notification(
     data: Data, admin_client: AsyncClient, user_client: AsyncClient
 ) -> None:
     start = datetime.now(tz=UTC).replace(microsecond=0)
@@ -119,7 +124,7 @@ async def test_user_notification(
 
 
 @pytest.mark.asyncio
-async def test_user_notification_read(
+async def test_notification_read(
     data: Data, admin_client: AsyncClient, user_client: AsyncClient
 ) -> None:
     to_send = data.read_json("notifications/multiple")
@@ -162,3 +167,145 @@ async def test_user_notification_read(
     for index in (0, 1):
         read = datetime.fromisoformat(updated_notifications[index]["read"])
         assert start <= read <= start + timedelta(seconds=2)
+
+
+async def setup_paginate_test(
+    data: Data, admin_client: AsyncClient, engine: AsyncEngine
+) -> None:
+    """Create some notifications to test pagination.
+
+    Parameters
+    ----------
+    data
+        Test data management object.
+    admin_client
+        Client that authenticates as an admin.
+    engine
+        Database engine.
+    """
+    to_send = data.read_json("notifications/pagination")
+    for notification in to_send:
+        r = await admin_client.post(
+            "/semaphore/v1/admin/notifications",
+            json=notification,
+        )
+        assert_http_response(r, 200)
+
+    # Adjust the creation timestamps to match the expected data.
+    expected = data.read_json("api/sent-pagination")
+    session = await create_async_session(engine)
+    async with session.begin():
+        for notification in expected:
+            id = int(notification["id"])
+            created = datetime.fromisoformat(notification["created"])
+            await session.execute(
+                update(SQLUserNotification)
+                .where(SQLUserNotification.id == id)
+                .values(created=datetime_to_db(created))
+            )
+
+
+@pytest.mark.asyncio
+async def test_notification_admin_paginate(
+    data: Data,
+    admin_client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    await setup_paginate_test(data, admin_client, engine)
+
+    # Retrieve all of the notifications.
+    r = await admin_client.get("/semaphore/v1/admin/notifications")
+    assert_http_response(r, 200)
+    notifications = r.json()
+    data.assert_json_matches(notifications, "api/sent-pagination")
+
+    # Retrieve the notifications one at a time to test pagination. Limit to
+    # the sender, which should produce the same results (all the notifications
+    # were sent by the same user), but helps check that the per-notification
+    # URLs don't include the search string.
+    r = await admin_client.get(
+        "/semaphore/v1/admin/notifications",
+        params={"limit": "1", "sender": notifications[0]["sender"]},
+    )
+    assert_http_response(r, 200)
+    assert r.json() == [notifications[0]]
+    assert r.headers["X-Total-Count"] == str(len(notifications))
+    links = PaginationLinkData.from_header(r.headers["Link"])
+    assert links.next_url
+    r = await admin_client.get(links.next_url)
+    assert_http_response(r, 200)
+    assert r.json() == [notifications[1]]
+    assert r.headers["X-Total-Count"] == str(len(notifications))
+    links = PaginationLinkData.from_header(r.headers["Link"])
+    assert links.next_url
+    assert links.prev_url
+    r = await admin_client.get(links.prev_url)
+    assert_http_response(r, 200)
+    assert r.json() == [notifications[0]]
+    r = await admin_client.get(links.next_url)
+    assert_http_response(r, 200)
+    assert r.json() == notifications[2:]
+
+    # Restrict to a specific user and request pagination.
+    r = await admin_client.get(
+        "/semaphore/v1/admin/notifications",
+        params={"limit": "1", "recipient": notifications[0]["recipient"]},
+    )
+    assert_http_response(r, 200)
+    assert r.json() == [notifications[0]]
+    links = PaginationLinkData.from_header(r.headers["Link"])
+    assert not links.next_url
+    assert r.headers["X-Total-Count"] == "1"
+
+    # Request the first two notifications by created date.
+    r = await admin_client.get(
+        "/semaphore/v1/admin/notifications",
+        params={"since": notifications[1]["created"]},
+    )
+    assert_http_response(r, 200)
+    assert r.json() == notifications[:2]
+
+    # Request the last two notifications by created date.
+    r = await admin_client.get(
+        "/semaphore/v1/admin/notifications",
+        params={"until": notifications[1]["created"]},
+    )
+    assert_http_response(r, 200)
+    assert r.json() == notifications[1:]
+
+
+@pytest.mark.asyncio
+async def test_notification_user_paginate(
+    *,
+    data: Data,
+    admin_client: AsyncClient,
+    user_client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    await setup_paginate_test(data, admin_client, engine)
+
+    # Retrieve all of the notifications.
+    r = await user_client.get("/semaphore/v1/notifications")
+    assert_http_response(r, 200)
+    notifications = r.json()
+    data.assert_json_matches(notifications, "api/notifications-pagination")
+
+    # Retrieve the notifications one at a time to test pagination.
+    r = await user_client.get(
+        "/semaphore/v1/notifications", params={"limit": "1"}
+    )
+    assert_http_response(r, 200)
+    assert r.json() == [notifications[0]]
+    assert r.headers["X-Total-Count"] == str(len(notifications))
+    links = PaginationLinkData.from_header(r.headers["Link"])
+    assert links.next_url
+    r = await user_client.get(links.next_url)
+    assert_http_response(r, 200)
+    assert r.json() == [notifications[1]]
+    assert r.headers["X-Total-Count"] == str(len(notifications))
+    links = PaginationLinkData.from_header(r.headers["Link"])
+    assert not links.next_url
+    assert links.prev_url
+    r = await user_client.get(links.prev_url)
+    assert_http_response(r, 200)
+    assert r.json() == [notifications[0]]


### PR DESCRIPTION
Add more comprehensive tests for pagination and limiting the list of notifications by various criteria in the admin API.