### PR TITLE
DM-55229: Move endpoint for retrieving user notifications

### DIFF
--- a/src/semaphore/handlers/v1/handlers.py
+++ b/src/semaphore/handlers/v1/handlers.py
@@ -173,7 +173,7 @@ async def admin_get_notification(
 
 
 @router.get(
-    "/notifications",
+    "/notifications/messages",
     summary="List notifications",
     description="List all current notifications for the authenticated user.",
     tags=["notifications"],
@@ -227,9 +227,9 @@ async def list_notifications(
 
 
 @router.get(
-    "/notifications/{id}",
-    summary="Get admin notification",
-    description="Retrieve a specific admin notification.",
+    "/notifications/messages/{id}",
+    summary="Get notification",
+    description="Retrieve a specific notification.",
     tags=["notifications"],
 )
 async def get_notification(

--- a/tests/data/notifications/user-multiple.json
+++ b/tests/data/notifications/user-multiple.json
@@ -7,7 +7,7 @@
       "gfm": "Notification three",
       "html": "Notification three"
     },
-    "url": "https://example.com/semaphore/v1/notifications/3"
+    "url": "https://example.com/semaphore/v1/notifications/messages/3"
   },
   {
     "created": "<ANY>",
@@ -17,7 +17,7 @@
       "gfm": "Notification two",
       "html": "Notification two"
     },
-    "url": "https://example.com/semaphore/v1/notifications/2"
+    "url": "https://example.com/semaphore/v1/notifications/messages/2"
   },
   {
     "created": "<ANY>",
@@ -27,6 +27,6 @@
       "gfm": "Notification one",
       "html": "Notification one"
     },
-    "url": "https://example.com/semaphore/v1/notifications/1"
+    "url": "https://example.com/semaphore/v1/notifications/messages/1"
   }
 ]

--- a/tests/data/notifications/user-one.json
+++ b/tests/data/notifications/user-one.json
@@ -7,6 +7,6 @@
       "gfm": "This is a *notification*",
       "html": "This is a <em>notification</em>"
     },
-    "url": "https://example.com/semaphore/v1/notifications/1"
+    "url": "https://example.com/semaphore/v1/notifications/messages/1"
   }
 ]

--- a/tests/data/notifications/user-pagination.json
+++ b/tests/data/notifications/user-pagination.json
@@ -7,7 +7,7 @@
       "gfm": "Notification two",
       "html": "Notification two"
     },
-    "url": "https://example.com/semaphore/v1/notifications/2"
+    "url": "https://example.com/semaphore/v1/notifications/messages/2"
   },
   {
     "created": "2026-06-17T15:00:00Z",
@@ -17,6 +17,6 @@
       "gfm": "Notification one",
       "html": "Notification one"
     },
-    "url": "https://example.com/semaphore/v1/notifications/1"
+    "url": "https://example.com/semaphore/v1/notifications/messages/1"
   }
 ]

--- a/tests/handlers/v1_test.py
+++ b/tests/handlers/v1_test.py
@@ -104,7 +104,7 @@ async def test_notification(
     # Retrieving messages for the recipient user should also retrieve a list
     # of message summaries containing that message, with the summary
     # formatted and a URL to the full message.
-    r = await user_client.get("/semaphore/v1/notifications")
+    r = await user_client.get("/semaphore/v1/notifications/messages")
     assert_http_response(r, 200)
     notifications = r.json()
     data.assert_json_matches(notifications, "notifications/user-one")
@@ -120,7 +120,7 @@ async def test_notification(
     assert datetime.fromisoformat(notification["created"]) == created
 
     # The admin user should not see the notification for the regular user.
-    r = await admin_client.get("/semaphore/v1/notifications")
+    r = await admin_client.get("/semaphore/v1/notifications/messages")
     assert_http_response(r, 200)
     assert r.json() == []
     r = await admin_client.get(notification_url)
@@ -149,7 +149,7 @@ async def test_notification_read(
 
     # Listing all unread notifications should return all three.
     r = await user_client.get(
-        "/semaphore/v1/notifications", params={"unread": "true"}
+        "/semaphore/v1/notifications/messages", params={"unread": "true"}
     )
     assert_http_response(r, 200)
     notifications = r.json()
@@ -163,14 +163,14 @@ async def test_notification_read(
 
     # Now, listing all unread notifications returns only the third.
     r = await user_client.get(
-        "/semaphore/v1/notifications", params={"unread": "true"}
+        "/semaphore/v1/notifications/messages", params={"unread": "true"}
     )
     assert_http_response(r, 200)
     assert r.json() == notifications[2:]
 
     # Listing all notifications still returns all three, but now with read
     # timestamps.
-    r = await user_client.get("/semaphore/v1/notifications")
+    r = await user_client.get("/semaphore/v1/notifications/messages")
     assert_http_response(r, 200)
     updated_notifications = r.json()
     notifications[0]["read"] = ANY
@@ -228,7 +228,7 @@ async def test_notification_service(
     assert r.json() == [sent]
 
     # The message should then appear for the user.
-    r = await user_client.get("/semaphore/v1/notifications")
+    r = await user_client.get("/semaphore/v1/notifications/messages")
     assert_http_response(r, 200)
     notifications = r.json()
     data.assert_json_matches(notifications, "notifications/user-one")
@@ -424,14 +424,14 @@ async def test_notification_user_paginate(
     await setup_paginate_test(data, admin_client, engine)
 
     # Retrieve all of the notifications.
-    r = await user_client.get("/semaphore/v1/notifications")
+    r = await user_client.get("/semaphore/v1/notifications/messages")
     assert_http_response(r, 200)
     notifications = r.json()
     data.assert_json_matches(notifications, "notifications/user-pagination")
 
     # Retrieve the notifications one at a time to test pagination.
     await check_pagination(
-        user_client, "/semaphore/v1/notifications", notifications
+        user_client, "/semaphore/v1/notifications/messages", notifications
     )
 
 


### PR DESCRIPTION
To avoid mixing the namespace for commands on user notifications and retrieving the notifications themselves, move listing notifications and retrieving a single notification to the prefix `/semaphore/v1/notifications/messages`, adding the `messages` path. Corresponding changes for admin and service notifications are not required because they don't have ancillary commands.