### PR TITLE
DM-55229: Add route to mark notifications unread

### DIFF
--- a/src/semaphore/handlers/v1/handlers.py
+++ b/src/semaphore/handlers/v1/handlers.py
@@ -19,7 +19,11 @@ from ...models.notification import (
     UserNotificationSummary,
     UserNotificationWithUrl,
 )
-from .models import BroadcastMessageModel, UserNotificationRead
+from .models import (
+    BroadcastMessageModel,
+    UserNotificationRead,
+    UserNotificationUnread,
+)
 
 router = APIRouter(route_class=SlackRouteErrorHandler)
 """FastAPI router for all v1 REST API endpoints."""
@@ -260,6 +264,27 @@ async def post_notification_read(
 ) -> None:
     service = context.factory.create_notification_service()
     await service.mark_read(read.ids, context.username)
+
+
+@router.post(
+    "/notifications/unread",
+    summary="Mark notifications unread",
+    description=(
+        "Mark a list of notifications unread. Notifications that do not exist"
+        " or that are not marked as read are silently ignored. Returning"
+        " errors for nonexistent notifications is not useful since there may"
+        " be race conditions with services revoking notifications."
+    ),
+    status_code=204,
+    tags=["notifications"],
+)
+async def post_notification_unread(
+    read: UserNotificationUnread,
+    *,
+    context: Annotated[RequestContext, Depends(context_dependency)],
+) -> None:
+    service = context.factory.create_notification_service()
+    await service.mark_unread(read.ids, context.username)
 
 
 @router.post(

--- a/src/semaphore/handlers/v1/models.py
+++ b/src/semaphore/handlers/v1/models.py
@@ -124,3 +124,19 @@ class UserNotificationRead(BaseModel):
             examples=[{"56", "57", "58", "59"}],
         ),
     ]
+
+
+class UserNotificationUnread(BaseModel):
+    """Notification IDs to mark as unread."""
+
+    ids: Annotated[
+        set[str],
+        Field(
+            title="Notification IDs",
+            description=(
+                "These notifications will be marked as unread if they are"
+                " currently marked as read."
+            ),
+            examples=[{"56", "57", "58", "59"}],
+        ),
+    ]

--- a/src/semaphore/services/notification.py
+++ b/src/semaphore/services/notification.py
@@ -286,3 +286,23 @@ class UserNotificationService:
         """
         async with self._session.begin():
             await self._storage.mark_read(required_recipient, ids)
+
+    async def mark_unread(
+        self, ids: set[str], required_recipient: str
+    ) -> None:
+        """Mark a set of notifications as unread.
+
+        Notifications that were not marked as read will be silently left
+        unchanged, as will notifications that don't exist. Error reporting is
+        not useful here since there may be a race condition with revoking
+        notifications.
+
+        Parameters
+        ----------
+        ids
+            Notification IDs to mark as unread.
+        required_recipient
+            Only operate on notifications sent to this username.
+        """
+        async with self._session.begin():
+            await self._storage.mark_unread(required_recipient, ids)

--- a/src/semaphore/storage/notification.py
+++ b/src/semaphore/storage/notification.py
@@ -161,3 +161,23 @@ class UserNotificationStore:
         notifications = await self._session.scalars(stmt)
         for notification in notifications:
             notification.read = now
+
+    async def mark_unread(self, recipient: str, ids: set[str]) -> None:
+        """Mark a set of notification IDs as unread.
+
+        Parameters
+        ----------
+        recipient
+            Only act on notifications sent to this recipient.
+        ids
+            Set of IDs to mark as unread.
+        """
+        ids_int = [int(v) for v in ids]
+        stmt = select(SQLUserNotification).where(
+            SQLUserNotification.recipient == recipient,
+            SQLUserNotification.id.in_(ids_int),
+            SQLUserNotification.read.isnot(None),
+        )
+        notifications = await self._session.scalars(stmt)
+        for notification in notifications:
+            notification.read = None

--- a/tests/handlers/v1_test.py
+++ b/tests/handlers/v1_test.py
@@ -180,6 +180,18 @@ async def test_notification_read(
         read = datetime.fromisoformat(updated_notifications[index]["read"])
         assert start <= read <= start + timedelta(seconds=2)
 
+    # Marking the second notification unread causes it to be returned again
+    # and clears the read timestamp.
+    ids = {"ids": [notifications[1]["id"]]}
+    r = await user_client.post("/semaphore/v1/notifications/unread", json=ids)
+    assert_http_response(r, 204)
+    notifications[1]["read"] = None
+    r = await user_client.get(
+        "/semaphore/v1/notifications/messages", params={"unread": "true"}
+    )
+    assert_http_response(r, 200)
+    assert r.json() == notifications[1:]
+
 
 @pytest.mark.asyncio
 async def test_notification_service(


### PR DESCRIPTION
Add a new `/semaphore/v1/notifications/unread` route that reverses the effect of `/semaphore/v1/notifications/read` and clears the read timestamp.