### PR TITLE
DM-55493: Refresh vendored ruff-shared.toml for ruff 0.16 CPY001

### DIFF
--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -36,6 +36,7 @@ ignore = [
     "ASYNC240", # we don't want to run filesystem operations on threads
     "BLE001",   # we want to catch and report Exception in background tasks
     "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "CPY001",   # No, every single file doesn't need its own copyright notice
     "D102",     # sometimes we use docstring inheritence
     "D104",     # don't see the point of documenting every package
     "D105",     # our style doesn't require docstrings for magic methods


### PR DESCRIPTION
## Summary

- ruff 0.16.0 (2026-07-23) stabilized CPY001 (missing-copyright-notice) out of preview. Because `ruff-shared.toml` uses `select = ["ALL"]`, the rule armed itself fleet-wide.
- Refreshes the vendored `ruff-shared.toml` from the current `lsst/templates` `fastapi_safir_app` template, which now ignores CPY001 (lsst/templates commit dd8e4b26). The diff is exactly the one added ignore line — verified by diffing against the fetched template copy.
- Config-only change; no source edits.

## Notes

- `pyproject.toml` required no changes: no redundant keys to prune, `known-first-party` already repo-specific and preserved.
- Local lint with the repo's pinned pre-commit ruff (0.15.20) passes cleanly.
- Checked with ruff 0.16.0 directly: 2 pre-existing ISC004 findings in `src/semaphore/models/notification.py` remain and are **expected/out of scope** for this PR — tracked separately per the campaign plan. No CPY001 findings remain, confirming the fix.

Jira: DM-55493