### PR TITLE
DM-55493: make implicit string concatenation explicit (ISC004)

### DIFF
--- a/src/semaphore/models/notification.py
+++ b/src/semaphore/models/notification.py
@@ -179,8 +179,10 @@ class UserNotificationWithUrl(UserNotification):
             title="URL",
             description="URL to the sent notification.",
             examples=[
-                "https://data.example.com/semaphore/v1/admin/notifications/"
-                "4561-a7513"
+                (
+                    "https://data.example.com/semaphore/v1/admin"
+                    "/notifications/4561-a7513"
+                )
             ],
         ),
     ]
@@ -251,8 +253,10 @@ class UserNotificationSummary(UserNotificationBase):
             title="URL",
             description="URL to the sent notification.",
             examples=[
-                "https://data.example.com/semaphore/v1/admin/notifications/"
-                "4561-a7513"
+                (
+                    "https://data.example.com/semaphore/v1/admin"
+                    "/notifications/4561-a7513"
+                )
             ],
         ),
     ]


### PR DESCRIPTION
## Background

Ruff 0.16.0 stabilized `ISC004` (*unparenthesized implicit string concatenation in a collection*), previously in preview. Running it against this repo surfaces two occurrences, both in `src/semaphore/models/notification.py`:

```
ISC004 Unparenthesized implicit string concatenation in collection
   --> src/semaphore/models/notification.py:182:17
   --> src/semaphore/models/notification.py:254:17
```

The pre-commit-pinned ruff in this repo is older and does **not** report these, so they are only visible with an explicit newer ruff.

The rule exists because `["a" "b"]` is ambiguous to a reader: it can be an intentional single string split across lines, or a two-element list with a forgotten comma. Ruff offers two dispositions and deliberately does not autofix (both are `--unsafe-fixes`), because only the author knows which was meant:

1. insert the missing comma, or
2. wrap the concatenation in parentheses to make it explicit.

## Why parentheses, not a comma

Both sites are the `url` field's `examples=[...]` on `UserNotificationWithUrl` and `UserNotificationSummary`. This is **intended** implicit concatenation. Evidence:

- Joined, it reads as one valid URL: `https://data.example.com/semaphore/v1/admin/notifications/4561-a7513`.
- That URL's trailing path segment is exactly the `id` field's own example on `UserNotificationBase` (`examples=["4561-a7513"]`). The example URL is the admin URL *for the example notification id* — the two are consistent by construction.
- The field is typed `HttpUrl` and described as "URL to the sent notification." Under the comma reading the second example would be the bare string `"4561-a7513"`, which is not a URL and would be nonsense for this field.

So the comma reading is wrong, and disposition 2 applies. The concatenation is wrapped in parentheses.

Because `line-length = 79` and the parentheses add an indent level, the split point moved one path segment earlier (`.../v1/admin` + `/notifications/4561-a7513`). The concatenated value is byte-identical to before.

## Effect on the OpenAPI schema

None. Parentheses are pure grouping in Python, so the emitted schema is unchanged. Verified by generating the spec via `semaphore.main:create_openapi` — both models still expose a single-element `examples` list:

```
UserNotificationSummary -> ["https://data.example.com/semaphore/v1/admin/notifications/4561-a7513"]
UserNotificationWithUrl -> ["https://data.example.com/semaphore/v1/admin/notifications/4561-a7513"]
```

(`docs/_static/openapi.json` is generated at docs-build time and gitignored, so there is no checked-in artifact to regenerate.) No test asserts on these example URLs — `tests/schema_test.py` covers Alembic migration currency, not the OpenAPI examples.

## Validation

- `uvx ruff@0.16.0 check --select PLR0917,ISC004 .` — was 2 `ISC004` errors, now **All checks passed!** (`PLR0917` was already clean.)
- `uvx ruff@0.16.0 check .` (repo config) — All checks passed.
- `uvx ruff@0.16.0 format --check` — already formatted.
- `nox -s typing` — success.
- `nox -s test` — 41 passed.

## No changelog fragment

The repo uses scriv (`changelog.d/`), but this change has no user-visible effect: the API, the OpenAPI schema, and the rendered documentation are all byte-identical. It is a lint-driven source-formatting change only.
