### PR TITLE
DM-55493: Adopt prek in place of pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "pytest-sugar",
     "pytest-xdist[psutil]",
     "testcontainers[postgres]",
+    "uv",
 ]
 docs = [
     "documenteer[guide]",
@@ -73,7 +74,6 @@ docs = [
 lint = [
     "prek",
     "ruff>=0.9",
-    "uv",
 ]
 nox = [
     "nox",

--- a/scripts/update-uv-version.sh
+++ b/scripts/update-uv-version.sh
@@ -7,11 +7,15 @@
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
-# Determine the current frozen uv version. Since the lint group depends on
-# pre-commit-uv, uv should always be part of its dependencies and thus updated
-# when running uv lock --upgrade, which should be run before this script.
-uv_version=$(uv export -q --no-hashes --only-group lint \
-             | grep ^uv== | sed 's/.*=//')
+# Expand non-matching globs to the empty list instead of the glob so that
+# packages that don't have one of the affected files can silently skip the
+# uv version rewrite rule that doesn't apply.
+shopt -s nullglob
+
+# Determine the current uv release version.
+uv_version=$(echo uv \
+             | uv pip compile - --quiet --no-header --no-annotate --no-config \
+             | sed -n 's/^uv==//p')
 
 # Replace the version in the env variables in GitHub Actions workflows.
 for f in .github/workflows/*.yaml; do
@@ -24,7 +28,8 @@ for f in .github/workflows/*.yaml; do
     fi
 done
 
-# Replace the version in any Dockerfiles.
+# Replace the version in any Dockerfiles. Allow for copying this script into
+# packages that have no Dockerfile.
 for f in Dockerfile*; do
     sed "s/uv:[0-9][0-9.]*/uv:$uv_version/" "$f" >"${f}.n"
     if ! cmp -s "$f" "${f}.n"; then

--- a/uv.lock
+++ b/uv.lock
@@ -2019,6 +2019,7 @@ dev = [
     { name = "pytest-sugar" },
     { name = "pytest-xdist", extra = ["psutil"] },
     { name = "testcontainers" },
+    { name = "uv" },
 ]
 docs = [
     { name = "documenteer", extra = ["guide"] },
@@ -2027,7 +2028,6 @@ docs = [
 lint = [
     { name = "prek" },
     { name = "ruff" },
-    { name = "uv" },
 ]
 nox = [
     { name = "nox" },
@@ -2076,6 +2076,7 @@ dev = [
     { name = "pytest-sugar" },
     { name = "pytest-xdist", extras = ["psutil"] },
     { name = "testcontainers", extras = ["postgres"] },
+    { name = "uv" },
 ]
 docs = [
     { name = "documenteer", extras = ["guide"] },
@@ -2084,7 +2085,6 @@ docs = [
 lint = [
     { name = "prek" },
     { name = "ruff", specifier = ">=0.9" },
-    { name = "uv" },
 ]
 nox = [
     { name = "nox" },


### PR DESCRIPTION
Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

semaphore was already half-migrated to prek (the `Makefile`, `noxfile.py`, and `.github/workflows/` already invoke `prek` directly, and the `lint` dependency group already listed `prek`). This PR finishes the migration:

- `pyproject.toml`: moved `uv` out of the `lint` dependency group and into the `dev` group (per migration step 3). `lint` now contains only `prek` and `ruff>=0.9`.
- `scripts/update-uv-version.sh`: replaced with the current `lsst/templates` fastapi_safir_app version (migration step 7). This was necessary, not just cosmetic — the old script derived `uv_version` from `uv export --only-group lint`, which breaks now that `uv` no longer lives in the `lint` group; the template version derives it independently via `uv pip compile`.
- `uv.lock`: relocked via `uv lock` (no `--upgrade`) to reflect the dependency-group move only. Diff confirms no other package versions moved (fastapi unchanged).

No changes were needed to `Makefile`, `noxfile.py`, or CI workflows — those already used `prek`. `.pre-commit-config.yaml` is untouched.

Verified: `uv run --only-group=lint prek run --all-files` and `nox -s lint` both pass.

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ